### PR TITLE
T23314: Add initial implementation AnimationsDbus library

### DIFF
--- a/animations-dbus/animations-dbus-client-effect.c
+++ b/animations-dbus/animations-dbus-client-effect.c
@@ -1,0 +1,270 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-client-effect.h"
+#include "animations-dbus-errors.h"
+#include "animations-dbus-main-context-private.h"
+#include "animations-dbus-objects.h"
+
+struct _AnimationsDbusClientEffect
+{
+  GObject parent_instance;
+};
+
+typedef struct _AnimationsDbusClientEffectPrivate
+{
+  AnimationsDbusAnimatableSurface *proxy;
+} AnimationsDbusClientEffectPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (AnimationsDbusClientEffect,
+                            animations_dbus_client_effect,
+                            G_TYPE_OBJECT)
+
+
+enum {
+  PROP_0,
+  PROP_PROXY,
+  PROP_TITLE,
+  PROP_SETTINGS,
+  PROP_SCHEMA,
+  NPROPS
+};
+
+static GParamSpec *animations_dbus_client_effect_properties[NPROPS];
+
+const char *
+animations_dbus_client_effect_get_object_path (AnimationsDbusClientEffect *client_effect)
+{
+  AnimationsDbusClientEffectPrivate *priv =
+    animations_dbus_client_effect_get_instance_private (client_effect);
+
+  return g_dbus_proxy_get_object_path (G_DBUS_PROXY (priv->proxy));
+}
+
+gboolean
+animations_dbus_client_effect_change_setting_finish (AnimationsDbusClientEffect  *client_effect G_GNUC_UNUSED,
+                                                     GAsyncResult                *result,
+                                                     GError                     **error)
+{
+  g_autoptr(GTask) task = G_TASK (result);
+  return g_task_propagate_boolean (task, error);
+}
+
+static void
+on_animations_dbus_client_effect_changed_setting (GObject      *source G_GNUC_UNUSED,
+                                                  GAsyncResult *result,
+                                                  gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClientEffect *client_effect =
+    ANIMATIONS_DBUS_CLIENT_EFFECT (g_task_get_task_data (task));
+  AnimationsDbusClientEffectPrivate *priv =
+    animations_dbus_client_effect_get_instance_private (client_effect);
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_animation_effect_call_change_setting_finish (ANIMATIONS_DBUS_ANIMATION_EFFECT (priv->proxy),
+                                                                    result,
+                                                                    &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_task_return_boolean (task, TRUE);
+}
+
+void
+animations_dbus_client_effect_change_setting_async (AnimationsDbusClientEffect *client_effect,
+                                                    const char                 *name,
+                                                    GVariant                   *value,
+                                                    GCancellable               *cancellable,
+                                                    GAsyncReadyCallback         callback,
+                                                    gpointer                    user_data)
+{
+  AnimationsDbusClientEffectPrivate *priv =
+    animations_dbus_client_effect_get_instance_private (client_effect);
+  GTask *task = g_task_new (client_effect, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, client_effect, NULL);
+
+  animations_dbus_animation_effect_call_change_setting (ANIMATIONS_DBUS_ANIMATION_EFFECT (priv->proxy),
+                                                        name,
+                                                        g_variant_new_variant (value),
+                                                        cancellable,
+                                                        on_animations_dbus_client_effect_changed_setting,
+                                                        task);
+}
+
+gboolean
+animations_dbus_client_effect_change_setting (AnimationsDbusClientEffect  *client_effect,
+                                              const char                  *name,
+                                              GVariant                    *value,
+                                              GError                     **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_effect_change_setting_async (client_effect,
+                                                      name,
+                                                      value,
+                                                      NULL,
+                                                      animations_dbus_got_async_func_result,
+                                                      &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_effect_change_setting_finish (client_effect,
+                                                              g_steal_pointer (&result),
+                                                              error);
+}
+
+static void
+animations_dbus_client_effect_set_property (GObject      *object,
+                                            guint         prop_id,
+                                            const GValue *value,
+                                            GParamSpec   *pspec)
+{
+  AnimationsDbusClientEffect *client_effect = ANIMATIONS_DBUS_CLIENT_EFFECT (object);
+  AnimationsDbusClientEffectPrivate *priv =
+    animations_dbus_client_effect_get_instance_private (client_effect);
+
+  switch (prop_id)
+    {
+    case PROP_PROXY:
+      priv->proxy = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_effect_get_property (GObject      *object,
+                                            unsigned int  prop_id,
+                                            GValue       *value,
+                                            GParamSpec   *pspec)
+{
+  AnimationsDbusClientEffect *client_effect = ANIMATIONS_DBUS_CLIENT_EFFECT (object);
+  AnimationsDbusClientEffectPrivate *priv =
+    animations_dbus_client_effect_get_instance_private (client_effect);
+
+  switch (prop_id)
+    {
+    case PROP_PROXY:
+      g_value_set_object (value, priv->proxy);
+      break;
+    case PROP_TITLE:
+      g_value_set_string (value,
+                          animations_dbus_animation_effect_get_title (ANIMATIONS_DBUS_ANIMATION_EFFECT (priv->proxy)));
+      break;
+    case PROP_SETTINGS:
+      g_value_set_variant (value,
+                           animations_dbus_animation_effect_get_settings (ANIMATIONS_DBUS_ANIMATION_EFFECT (priv->proxy)));
+      break;
+    case PROP_SCHEMA:
+      g_value_set_variant (value,
+                           animations_dbus_animation_effect_get_schema (ANIMATIONS_DBUS_ANIMATION_EFFECT (priv->proxy)));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_effect_dispose (GObject *object)
+{
+  AnimationsDbusClientEffect *client = ANIMATIONS_DBUS_CLIENT_EFFECT (object);
+  AnimationsDbusClientEffectPrivate *priv = animations_dbus_client_effect_get_instance_private (client);
+
+  g_clear_object (&priv->proxy);
+
+  G_OBJECT_CLASS (animations_dbus_client_effect_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_client_effect_init (AnimationsDbusClientEffect *client G_GNUC_UNUSED)
+{
+}
+
+static GVariant *
+empty_vardict (void)
+{
+  GVariantDict vardict;
+
+  g_variant_dict_init (&vardict, NULL);
+  return g_variant_dict_end (&vardict);
+}
+
+static void
+animations_dbus_client_effect_class_init (AnimationsDbusClientEffectClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = animations_dbus_client_effect_set_property;
+  object_class->get_property = animations_dbus_client_effect_get_property;
+  object_class->dispose = animations_dbus_client_effect_dispose;
+
+  animations_dbus_client_effect_properties[PROP_PROXY] =
+    g_param_spec_object ("proxy",
+                         "Proxy",
+                         "The DBus proxy for this animation effect",
+                         ANIMATIONS_DBUS_TYPE_ANIMATION_EFFECT,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  animations_dbus_client_effect_properties[PROP_TITLE] =
+    g_param_spec_string ("title",
+                         "Title",
+                         "The title for this effect",
+                         "",
+                         G_PARAM_READABLE);
+
+  animations_dbus_client_effect_properties[PROP_SETTINGS] =
+    g_param_spec_variant ("settings",
+                          "Settings",
+                          "The settings for this effect",
+                          G_VARIANT_TYPE ("a{sv}"),
+                          empty_vardict (),
+                          G_PARAM_READABLE);
+
+  animations_dbus_client_effect_properties[PROP_SCHEMA] =
+    g_param_spec_variant ("schema",
+                          "Schema",
+                          "The schema for this effect's settings",
+                          G_VARIANT_TYPE ("a{sv}"),
+                          empty_vardict (),
+                          G_PARAM_READABLE);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     animations_dbus_client_effect_properties);
+}
+
+AnimationsDbusClientEffect *
+animations_dbus_client_effect_new_for_proxy (AnimationsDbusAnimationEffect *effect_proxy)
+{
+  return g_object_new (ANIMATIONS_DBUS_TYPE_CLIENT_EFFECT,
+                       "proxy", effect_proxy,
+                       NULL);
+}

--- a/animations-dbus/animations-dbus-client-effect.h
+++ b/animations-dbus/animations-dbus-client-effect.h
@@ -1,0 +1,54 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib.h>
+
+#include <animations-dbus-objects.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_CLIENT_EFFECT animations_dbus_client_effect_get_type ()
+G_DECLARE_FINAL_TYPE (AnimationsDbusClientEffect, animations_dbus_client_effect, ANIMATIONS_DBUS, CLIENT_EFFECT, GObject)
+
+const char * animations_dbus_client_effect_get_object_path (AnimationsDbusClientEffect *client_effect);
+
+gboolean animations_dbus_client_effect_change_setting_finish (AnimationsDbusClientEffect  *client_effect,
+                                                              GAsyncResult                *result,
+                                                              GError                     **error);
+
+void animations_dbus_client_effect_change_setting_async (AnimationsDbusClientEffect *client_effect,
+                                                         const char                 *name,
+                                                         GVariant                   *value,
+                                                         GCancellable               *cancellable,
+                                                         GAsyncReadyCallback         callback,
+                                                         gpointer                    user_data);
+
+gboolean animations_dbus_client_effect_change_setting (AnimationsDbusClientEffect  *client_effect,
+                                                       const char                  *name,
+                                                       GVariant                    *value,
+                                                       GError                     **error);
+
+AnimationsDbusClientEffect * animations_dbus_client_effect_new_for_proxy (AnimationsDbusAnimationEffect *proxy);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-client-object.c
+++ b/animations-dbus/animations-dbus-client-object.c
@@ -1,0 +1,802 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-client-effect.h"
+#include "animations-dbus-client-object.h"
+#include "animations-dbus-client-surface.h"
+#include "animations-dbus-errors.h"
+#include "animations-dbus-main-context-private.h"
+#include "animations-dbus-objects.h"
+
+struct _AnimationsDbusClient
+{
+  GObject parent_instance;
+};
+
+typedef struct _AnimationsDbusClientPrivate
+{
+  GDBusConnection                      *connection;
+  AnimationsDbusConnectionManagerProxy *connection_manager_proxy;
+  AnimationsDbusConnectionManagerProxy *animation_manager_proxy;
+} AnimationsDbusClientPrivate;
+
+static void animations_dbus_client_async_initable_interface_init (GAsyncInitableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (AnimationsDbusClient,
+                         animations_dbus_client,
+                         G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_ASYNC_INITABLE,
+                                                animations_dbus_client_async_initable_interface_init)
+                         G_ADD_PRIVATE (AnimationsDbusClient))
+
+enum {
+  PROP_0,
+  PROP_CONNECTION,
+  NPROPS
+};
+
+static GParamSpec *animations_dbus_client_properties[NPROPS];
+
+/**
+ * animations_dbus_client_list_surfaces_finish:
+ * @client: An #AnimationsDbusClient
+ * @result: A #GAsyncResult
+ * @error: A #GError
+ *
+ * Finish asynchronously listing surfaces on the server end. There is no
+ * guarantee that the surfaces returned exist on the server end by the time
+ * they are actually to be used. If a method call is made on a service that
+ * does not exist, an error will be returned.
+ *
+ * Returns: (transfer container) (element-type AnimationsDbusClientSurface):
+ *          A #GPtrArray of #AnimationsDbusClientSurface, with each member
+ *          connected to a surface on the bus.
+ */
+GPtrArray *
+animations_dbus_client_list_surfaces_finish (AnimationsDbusClient  *client G_GNUC_UNUSED,
+                                             GAsyncResult          *result,
+                                             GError               **error)
+{
+  return g_task_propagate_pointer (G_TASK (result), error);
+} 
+
+typedef struct {
+  int           ref_count;
+  unsigned int  remaining;
+  GPtrArray    *proxies_array;
+  GTask        *task;
+  GError       *error;
+} AllProxiesCountdown;
+
+static AllProxiesCountdown *
+all_proxies_countdown_new (unsigned int  n_surfaces,
+                           GTask        *task)
+{
+  AllProxiesCountdown *countdown = g_new0 (AllProxiesCountdown, 1);
+
+  countdown->ref_count = 1;
+  countdown->remaining = n_surfaces;
+  countdown->proxies_array = g_ptr_array_new_full (n_surfaces, g_object_unref);
+  countdown->task = g_object_ref (task);
+  countdown->error = NULL;
+
+  return countdown;
+}
+
+static AllProxiesCountdown *
+all_proxies_countdown_ref (AllProxiesCountdown *countdown)
+{
+  g_atomic_int_inc (&countdown->ref_count);
+  return countdown;
+}
+
+static void
+all_proxies_countdown_unref (AllProxiesCountdown *countdown)
+{
+  if (g_atomic_int_dec_and_test (&countdown->ref_count))
+    {
+      g_clear_pointer (&countdown->proxies_array, g_ptr_array_unref);
+      g_clear_object (&countdown->task);
+      g_clear_error (&countdown->error);
+
+      g_free (countdown);
+    }
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (AllProxiesCountdown, all_proxies_countdown_unref)
+
+static void
+on_constructed_animatable_surface_proxy (GObject      *source_object G_GNUC_UNUSED,
+                                         GAsyncResult *result,
+                                         gpointer      user_data)
+{
+  g_autoptr(AllProxiesCountdown) countdown = user_data;
+
+  /* Note that since the asynchronous call completed, we should still
+   * decrement remaining here, even if we will set an error on the AllProxiesCountdown -
+   * we need all the async calls to complete before we finally return
+   * an error to the caller, since the remaining async calls have a
+   * reference on AllProxiesCountdown. */
+  unsigned int remaining_after_construction = --countdown->remaining;
+
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(AnimationsDbusAnimatableSurfaceProxy) animatable_surface_proxy =
+    ANIMATIONS_DBUS_ANIMATABLE_SURFACE_PROXY (animations_dbus_animatable_surface_proxy_new_finish (result, &local_error));
+
+  if (animatable_surface_proxy == NULL)
+    {
+      /* Note that on failure we don't necessarily want to set an error
+       * on the task itself, since g_task_return_error will cause the
+       * task to complete on the next main context iteration, which
+       * may happen before all the other async calls have completed.
+       *
+       * Instead, we set the error on AllProxiesCountdown and wait
+       * until they have all completed to return the first error that
+       * occurred on the task (all other errors are suppressed).
+       *
+       * We also don't want to return early here either - we must
+       * complete all the asynchronous tasks and run the cleanup
+       * code to return.
+       */
+      if (countdown->error == NULL)
+        countdown->error = g_steal_pointer (&local_error);
+    }
+  else
+    {
+      g_ptr_array_add (countdown->proxies_array,
+                       animations_dbus_client_surface_new_for_proxy (g_steal_pointer (&animatable_surface_proxy)));
+    }
+
+   if (remaining_after_construction == 0)
+    {
+      GTask *task = countdown->task;
+
+      if (countdown->error != NULL)
+        {
+          g_task_return_error (task, g_steal_pointer (&countdown->error));
+          return;
+        }
+
+      g_task_return_pointer (task,
+                             g_steal_pointer (&countdown->proxies_array),
+                             (GDestroyNotify) g_ptr_array_unref);
+    }
+}
+
+static void
+on_animations_dbus_client_list_surfaces (GObject      *source_object,
+                                         GAsyncResult *result,
+                                         gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (g_task_get_task_data (task));
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_auto(GStrv) surface_object_paths_array = NULL;
+  g_autoptr(GError) local_error = NULL;
+  
+
+  if (!animations_dbus_animation_manager_call_list_surfaces_finish (ANIMATIONS_DBUS_ANIMATION_MANAGER (source_object),
+                                                                    &surface_object_paths_array,
+                                                                    result,
+                                                                    &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  /* If the surface_object_paths_array is empty, we need to return now, since
+   * animations_dbus_animatable_surface_proxy_new will never be called. */
+  if (*surface_object_paths_array == NULL)
+    {
+      g_task_return_pointer (task, g_ptr_array_new (), NULL);
+      return;
+    }
+
+  /* Now that we have the surface names array, allocate an
+   * AllProxiesCountdown and query all the properties of the
+   * surfaces that are available. We don't care about ordering. */
+  g_autoptr(AllProxiesCountdown) countdown =
+    all_proxies_countdown_new (g_strv_length (surface_object_paths_array),
+                               task);
+
+  for (const char **surface_object_path_iter = (const char **) surface_object_paths_array;
+       *surface_object_path_iter != NULL;
+       ++surface_object_path_iter)
+    {
+      animations_dbus_animatable_surface_proxy_new (priv->connection,
+                                                    G_DBUS_PROXY_FLAGS_NONE,
+                                                    "com.endlessm.Libanimation",
+                                                    *surface_object_path_iter,
+                                                    g_task_get_cancellable (task),
+                                                    on_constructed_animatable_surface_proxy,
+                                                    all_proxies_countdown_ref (countdown));
+    }
+}
+
+void
+animations_dbus_client_list_surfaces_async (AnimationsDbusClient *client,
+                                            GCancellable         *cancellable,
+                                            GAsyncReadyCallback   callback,
+                                            gpointer              user_data)
+{
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autoptr(GTask) task = g_task_new (client, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, client, NULL);
+
+  animations_dbus_animation_manager_call_list_surfaces (ANIMATIONS_DBUS_ANIMATION_MANAGER (priv->animation_manager_proxy),
+                                                        cancellable,
+                                                        on_animations_dbus_client_list_surfaces,
+                                                        g_steal_pointer (&task));
+}
+
+/**
+ * animations_dbus_client_list_surfaces:
+ * @client: An #AnimationsDbusClientq
+ * @error: A #GError
+ *
+ * List all the available surfaces that can have animations attached to
+ * them.
+ *
+ * Returns: (transfer container) (element-type AnimationsDbusClientSurface):
+ *          A #GPtrArray of #AnimationsDbusClientSurface, with each member
+ *          connected to a surface on the bus, or %NULL with @error set on
+ *          failure.
+ */
+GPtrArray *
+animations_dbus_client_list_surfaces (AnimationsDbusClient  *client,
+                                      GError               **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_list_surfaces_async (client,
+                                              NULL,
+                                              animations_dbus_got_async_func_result,
+                                              &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_list_surfaces_finish (client,
+                                                      g_steal_pointer (&result),
+                                                      error);
+}
+
+/**
+ * animations_dbus_client_create_animation_effect_finish:
+ * @client: An #AnimationsDbusClient
+ * @result: A #GAsyncResult
+ * @error: A #GError
+ *
+ * Finish asynchronously creating an AnimationsDbusClientEffect.
+ *
+ * Returns: (transfer full): An #AnimationsDbusClientEffect that connects
+ *          to an effect created on the bus.
+ */
+AnimationsDbusClientEffect *
+animations_dbus_client_create_animation_effect_finish (AnimationsDbusClient  *client G_GNUC_UNUSED,
+                                                       GAsyncResult          *result,
+                                                       GError               **error)
+{
+  g_autoptr(GTask) task = G_TASK (result);
+  return g_task_propagate_pointer (task, error);
+} 
+
+static void
+on_constructed_animation_effect_callback (GObject      *source G_GNUC_UNUSED,
+                                          GAsyncResult *result,
+                                          gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(AnimationsDbusAnimationEffectProxy) effect_proxy =
+    ANIMATIONS_DBUS_ANIMATION_EFFECT_PROXY (animations_dbus_animation_effect_proxy_new_finish (result,
+                                                                                               &local_error));
+
+  if (effect_proxy == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_task_return_pointer (task,
+                         animations_dbus_client_effect_new_for_proxy (g_steal_pointer (&effect_proxy)),
+                         g_object_unref);
+}
+
+static void
+on_animations_dbus_client_created_animation_effect (GObject      *source,
+                                                    GAsyncResult *result,
+                                                    gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (g_task_get_task_data (task));
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autofree char *object_path = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_animation_manager_call_create_animation_effect_finish (ANIMATIONS_DBUS_ANIMATION_MANAGER (source),
+                                                                              &object_path,
+                                                                              result,
+                                                                              &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  animations_dbus_animation_effect_proxy_new (priv->connection,
+                                              G_DBUS_PROXY_FLAGS_NONE,
+                                              "com.endlessm.Libanimation",
+                                              object_path,
+                                              g_task_get_cancellable (task),
+                                              on_constructed_animation_effect_callback,
+                                              task);
+}
+
+void
+animations_dbus_client_create_animation_effect_async (AnimationsDbusClient *client,
+                                                      const char           *title,
+                                                      const char           *animation,
+                                                      GVariant             *settings,
+                                                      GCancellable         *cancellable,
+                                                      GAsyncReadyCallback   callback,
+                                                      gpointer              user_data)
+{
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autoptr(GTask) task = g_task_new (client, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, client, NULL);
+
+  animations_dbus_animation_manager_call_create_animation_effect (ANIMATIONS_DBUS_ANIMATION_MANAGER (priv->animation_manager_proxy),
+                                                                  title,
+                                                                  animation,
+                                                                  settings,
+                                                                  cancellable,
+                                                                  on_animations_dbus_client_created_animation_effect,
+                                                                  g_steal_pointer (&task));
+}
+
+/**
+ * animations_dbus_client_create_animation_effect:
+ * @client: An #AnimationsDbusClient
+ * @title: The title of the effect, for later reference
+ * @name: The name of the animation to use. Use animations_dbus_client_surface_list_available_effects
+ *        to find out what effects can be created on a surface.
+ * @settings: The initial settings.
+ * @error: A #GError
+ *
+ * Create an #AnimationsDbusClientEffect using the animation specified by @name
+ * and titled with @title.
+ *
+ * Returns: (transfer full): An #AnimationsDbusClientEffect that connects
+ *          to an effect created on the bus, or %NULL with @error set on failure.
+ */
+AnimationsDbusClientEffect *
+animations_dbus_client_create_animation_effect (AnimationsDbusClient  *client,
+                                                const char            *title,
+                                                const char            *name,
+                                                GVariant              *settings,
+                                                GError               **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_create_animation_effect_async (client,
+                                                        title,
+                                                        name,
+                                                        settings,
+                                                        NULL,
+                                                        animations_dbus_got_async_func_result,
+                                                        &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_create_animation_effect_finish (client,
+                                                                g_steal_pointer (&result),
+                                                                error);
+}
+
+/**
+ * animations_dbus_client_new_finish:
+ * @source: The object passed to the #GAsyncReadyCallback.
+ * @result: A #GAsyncResult.
+ * @error: A #GError.
+ *
+ * Complete the call to animations_dbus_client_new_async.
+ *
+ * Returns: (transfer full): A new #AnimationsDbusClient or %NULL with
+ *          @error set in case of failure.
+ */
+AnimationsDbusClient *
+animations_dbus_client_new_finish (GObject       *source,
+                                   GAsyncResult  *result,
+                                   GError       **error)
+{
+  return ANIMATIONS_DBUS_CLIENT (g_async_initable_new_finish (G_ASYNC_INITABLE (source),
+                                                              result,
+                                                              error));
+}
+
+static void
+on_created_animation_manager_proxy (GObject      *source G_GNUC_UNUSED,
+                                    GAsyncResult *result,
+                                    gpointer      user_data)
+{
+  GTask *task = user_data;
+  AnimationsDbusClient *client = g_task_get_task_data (task);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(AnimationsDbusAnimationManagerProxy) animation_manager_proxy =
+    ANIMATIONS_DBUS_ANIMATION_MANAGER_PROXY (animations_dbus_animation_manager_proxy_new_finish (result,
+                                                                                                 &local_error));
+
+  if (animation_manager_proxy == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  priv->animation_manager_proxy = g_steal_pointer (&animation_manager_proxy);
+
+  /* Done with async construction, return TRUE on
+   * the async task. */
+  g_task_return_boolean (task, TRUE);
+}
+
+static void
+on_call_register_client_finished (GObject      *source,
+                                  GAsyncResult *result,
+                                  gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClient *client = g_task_get_task_data (task);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autofree char *object_path = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_connection_manager_call_register_client_finish (ANIMATIONS_DBUS_CONNECTION_MANAGER (source),
+                                                                       &object_path,
+                                                                       result,
+                                                                       &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    } 
+
+  animations_dbus_animation_manager_proxy_new (priv->connection,
+                                               G_DBUS_PROXY_FLAGS_NONE,
+                                               "com.endlessm.Libanimation",
+                                               object_path,
+                                               g_task_get_cancellable (task),
+                                               on_created_animation_manager_proxy,
+                                               task);
+}
+
+static void
+on_created_connection_manager_proxy (GObject      *source G_GNUC_UNUSED,
+                                     GAsyncResult *result,
+                                     gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClient *client = g_task_get_task_data (task);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(AnimationsDbusConnectionManagerProxy) connection_manager_proxy =
+    ANIMATIONS_DBUS_CONNECTION_MANAGER_PROXY (animations_dbus_connection_manager_proxy_new_finish (result,
+                                                                                                   &local_error));
+
+  if (connection_manager_proxy == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  priv->connection_manager_proxy = g_steal_pointer (&connection_manager_proxy);
+
+  /* Now that we have a proxy to the connection manager, create an
+   * AnimationManager object on the remote end by calling RegisterClient. This
+   * will return an object path which we can use the create an
+   * AnimationManager proxy. */
+  animations_dbus_connection_manager_call_register_client (ANIMATIONS_DBUS_CONNECTION_MANAGER (priv->connection_manager_proxy),
+                                                           g_task_get_cancellable (task),
+                                                           on_call_register_client_finished,
+                                                           task);
+}
+
+static inline void
+create_animations_dbus_connection_manager_proxy (GDBusConnection *connection,
+                                                 GTask           *task)
+{
+  animations_dbus_connection_manager_proxy_new (connection,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                "com.endlessm.Libanimation",
+                                                "/com/endlessm/Libanimation/ConnectionManager",
+                                                g_task_get_cancellable (task),
+                                                on_created_connection_manager_proxy,
+                                                task);
+}
+
+static void
+on_got_session_bus (GObject      *source G_GNUC_UNUSED,
+                    GAsyncResult *result,
+                    gpointer      user_data)
+{
+  GTask *task = user_data;
+  AnimationsDbusClient *client = g_task_get_task_data (task);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GDBusConnection) connection = g_bus_get_finish (result, &local_error);
+
+  if (connection == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    } 
+
+  priv->connection = g_steal_pointer (&connection);
+
+  /* Now that we have the session bus, create a proxy for
+   * the com.endlessm.Libanimation.ConnectionManager interface
+   * com.endlessm.Libanimation:/com/endlessm/Libanimation/ConnectionManager */
+  create_animations_dbus_connection_manager_proxy (priv->connection, task);
+}
+
+static gboolean
+animations_dbus_client_init_finish (GAsyncInitable  *initable,
+                                    GAsyncResult    *result,
+                                    GError         **error)
+{
+  GTask *task = G_TASK (result);
+  g_return_val_if_fail (g_task_is_valid (task, initable), FALSE);
+
+  return g_task_propagate_boolean (task, error);
+}
+
+static void
+animations_dbus_client_init_async (GAsyncInitable      *initable,
+                                   int                  io_priority G_GNUC_UNUSED,
+                                   GCancellable        *cancellable,
+                                   GAsyncReadyCallback  callback,
+                                   gpointer             user_data)
+{
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (initable);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+  GTask *task = g_task_new (initable, cancellable, callback, user_data);
+
+  /* Async initialization does not own the client, the caller
+   * owns it. */
+  g_task_set_task_data (task, client, NULL);
+
+  /* Already initialized */
+  if (priv->animation_manager_proxy != NULL)
+    {
+      g_task_return_boolean (task, TRUE);
+      return;
+    }
+
+  /* The caller provided us with a connection on construction. This
+   * means that we do not have to get the session bus singleton
+   * and can continue with calling
+   * create_animations_dbus_connection_manager_proxy */
+  if (priv->connection != NULL)
+    {
+      create_animations_dbus_connection_manager_proxy (priv->connection,
+                                                       task);
+      return;
+    }
+
+  g_bus_get (G_BUS_TYPE_SESSION,
+             cancellable,
+             on_got_session_bus,
+             task);
+}
+
+static void
+animations_dbus_client_async_initable_interface_init (GAsyncInitableIface *iface)
+{
+  iface->init_async = animations_dbus_client_init_async;
+  iface->init_finish = animations_dbus_client_init_finish;
+}
+
+static void
+animations_dbus_client_set_property (GObject      *object,
+                                     guint         prop_id,
+                                     const GValue *value,
+                                     GParamSpec   *pspec)
+{
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (object);
+  AnimationsDbusClientPrivate *priv =
+    animations_dbus_client_get_instance_private (client);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      priv->connection = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_get_property (GObject    *object,
+                                     guint       prop_id,
+                                     GValue     *value,
+                                     GParamSpec *pspec)
+{
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (object);
+  AnimationsDbusClientPrivate *priv =
+    animations_dbus_client_get_instance_private (client);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_value_set_object (value, priv->connection);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_dispose (GObject *object)
+{
+  AnimationsDbusClient *client = ANIMATIONS_DBUS_CLIENT (object);
+  AnimationsDbusClientPrivate *priv = animations_dbus_client_get_instance_private (client);
+
+  g_clear_object (&priv->animation_manager_proxy);
+  g_clear_object (&priv->connection_manager_proxy);
+  g_clear_object (&priv->connection);
+
+  G_OBJECT_CLASS (animations_dbus_client_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_client_init (AnimationsDbusClient *client G_GNUC_UNUSED)
+{
+}
+
+static void
+animations_dbus_client_class_init (AnimationsDbusClientClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = animations_dbus_client_dispose;
+  object_class->set_property = animations_dbus_client_set_property;
+  object_class->get_property = animations_dbus_client_get_property;
+
+  animations_dbus_client_properties[PROP_CONNECTION] =
+    g_param_spec_object ("connection",
+                         "A GDBusConnection",
+                         "The connection connecting this client to the session bus",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     animations_dbus_client_properties);
+}
+
+void
+animations_dbus_client_new_async (GCancellable        *cancellable,
+                                  GAsyncReadyCallback  callback,
+                                  gpointer             user_data)
+{
+  g_async_initable_new_async (ANIMATIONS_DBUS_TYPE_CLIENT,
+                              G_PRIORITY_DEFAULT,
+                              cancellable,
+                              callback,
+                              user_data,
+                              NULL);
+}
+
+void
+animations_dbus_client_new_with_connection_async (GDBusConnection     *connection,
+                                                  GCancellable        *cancellable,
+                                                  GAsyncReadyCallback  callback,
+                                                  gpointer             user_data)
+{
+  g_async_initable_new_async (ANIMATIONS_DBUS_TYPE_CLIENT,
+                              G_PRIORITY_DEFAULT,
+                              cancellable,
+                              callback,
+                              user_data,
+                              "connection", connection,
+                              NULL);
+}
+
+/**
+ * animations_dbus_client_new:
+ * @error: A #GError.
+ *
+ * Create a new AnimationsDbusClient by connecting to the session bus
+ * and registering the connection with the owner of com.endlessm.Libanimation.
+ *
+ * Returns: (transfer full): A new #AnimationsDbusClient or %NULL with
+ *          @error set in case of failure.
+ */
+AnimationsDbusClient *
+animations_dbus_client_new (GError **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(AnimationsDbusClient) client = g_object_new (ANIMATIONS_DBUS_TYPE_CLIENT, NULL);
+
+  g_async_initable_init_async (G_ASYNC_INITABLE (client),
+                               G_PRIORITY_DEFAULT,
+                               NULL,
+                               animations_dbus_got_async_func_result,
+                               &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  if (!g_async_initable_init_finish (G_ASYNC_INITABLE (client),
+                                     g_steal_pointer (&result),
+                                     error))
+    return NULL;
+
+  return g_steal_pointer (&client);
+}
+
+/**
+ * animations_dbus_client_new_with_connection:
+ * @connection: A #GDBusConnection.
+ * @error: A #GError.
+ *
+ * Create a new AnimationsDbusClient by using the existing connection
+ * and registering the connection with the owner of com.endlessm.Libanimation.
+ *
+ * Returns: (transfer full): A new #AnimationsDbusClient or %NULL with
+ *          @error set in case of failure.
+ */
+AnimationsDbusClient *
+animations_dbus_client_new_with_connection (GDBusConnection  *connection,
+                                            GError          **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(AnimationsDbusClient) client =
+    g_object_new (ANIMATIONS_DBUS_TYPE_CLIENT,
+                  "connection", connection,
+                  NULL);
+
+  g_async_initable_init_async (G_ASYNC_INITABLE (client),
+                               G_PRIORITY_DEFAULT,
+                               NULL,
+                               animations_dbus_got_async_func_result,
+                               &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  if (!g_async_initable_init_finish (G_ASYNC_INITABLE (client),
+                                     g_steal_pointer (&result),
+                                     error))
+    return NULL;
+
+  return g_steal_pointer (&client);
+}

--- a/animations-dbus/animations-dbus-client-object.h
+++ b/animations-dbus/animations-dbus-client-object.h
@@ -1,0 +1,85 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib.h>
+
+#include <animations-dbus-client-effect.h>
+#include <animations-dbus-objects.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_CLIENT animations_dbus_client_get_type ()
+G_DECLARE_FINAL_TYPE (AnimationsDbusClient, animations_dbus_client, ANIMATIONS_DBUS, CLIENT, GObject)
+
+AnimationsDbusClientEffect * animations_dbus_client_create_animation_effect_finish (AnimationsDbusClient  *client,
+                                                                                    GAsyncResult          *result,
+                                                                                    GError               **error);
+
+void animations_dbus_client_create_animation_effect_async (AnimationsDbusClient *client,
+                                                           const char           *title,
+                                                           const char           *name,
+                                                           GVariant             *settings,
+                                                           GCancellable         *cancellable,
+                                                           GAsyncReadyCallback   callback,
+                                                           gpointer              user_data);
+
+
+AnimationsDbusClientEffect * animations_dbus_client_create_animation_effect (AnimationsDbusClient  *client,
+                                                                             const char            *title,
+                                                                             const char            *name,
+                                                                             GVariant              *settings,
+                                                                             GError               **error);
+
+GPtrArray * animations_dbus_client_list_surfaces_finish (AnimationsDbusClient  *client,
+                                                         GAsyncResult          *result,
+                                                         GError               **error);
+
+void animations_dbus_client_list_surfaces_async (AnimationsDbusClient *client,
+                                                 GCancellable         *cancellable,
+                                                 GAsyncReadyCallback   callback,
+                                                 gpointer              user_data);
+
+GPtrArray * animations_dbus_client_list_surfaces (AnimationsDbusClient  *client,
+                                                  GError               **error);
+
+AnimationsDbusClient * animations_dbus_client_new_finish (GObject       *source,
+                                                          GAsyncResult  *result,
+                                                          GError       **error);
+
+void animations_dbus_client_new_async (GCancellable        *cancellable,
+                                       GAsyncReadyCallback  callback,
+                                       gpointer             user_data);
+
+
+void animations_dbus_client_new_with_connection_async (GDBusConnection     *connection,
+                                                       GCancellable        *cancellable,
+                                                       GAsyncReadyCallback  callback,
+                                                       gpointer             user_data);
+
+AnimationsDbusClient * animations_dbus_client_new (GError **error);
+
+AnimationsDbusClient * animations_dbus_client_new_with_connection (GDBusConnection  *connection,
+                                                                   GError          **error);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-client-surface.c
+++ b/animations-dbus/animations-dbus-client-surface.c
@@ -1,0 +1,450 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-client-effect.h"
+#include "animations-dbus-client-surface.h"
+#include "animations-dbus-errors.h"
+#include "animations-dbus-main-context-private.h"
+#include "animations-dbus-objects.h"
+
+struct _AnimationsDbusClientSurface
+{
+  GObject parent_instance;
+};
+
+typedef struct _AnimationsDbusClientSurfacePrivate
+{
+  AnimationsDbusAnimatableSurface *proxy;
+} AnimationsDbusClientSurfacePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (AnimationsDbusClientSurface,
+                            animations_dbus_client_surface,
+                            G_TYPE_OBJECT)
+
+
+enum {
+  PROP_0,
+  PROP_PROXY,
+  PROP_TITLE,
+  PROP_GEOMETRY,
+  PROP_EFFECTS,
+  NPROPS
+};
+
+static GParamSpec *animations_dbus_client_surface_properties[NPROPS];
+
+/**
+ * animations_dbus_client_surface_list_available_effects_finish:
+ * @surface: An #AnimationsDbusClientSurface
+ * @result: A #GAsyncResult
+ * @error: A #GError
+ *
+ * Finish the call to animations_dbus_client_surface_list_available_effects and
+ * return the available effects for each event.
+ *
+ * Returns: (transfer container) (element-type utf8 GStrv): A #GHashTable mapping
+ *          event names to a list of possible animation names that can be used
+ *          when attaching effects to that event.
+ */
+GHashTable *
+animations_dbus_client_surface_list_available_effects_finish (AnimationsDbusClientSurface  *surface G_GNUC_UNUSED,
+                                                              GAsyncResult                 *result,
+                                                              GError                      **error)
+{
+  g_autoptr(GTask) task = G_TASK (result);
+  return g_task_propagate_pointer (task, error);
+}
+
+static GHashTable *
+available_effects_variant_to_hash_table (GVariant *available_effects_variant)
+{
+  g_autoptr(GHashTable) ht = g_hash_table_new_full (g_str_hash,
+                                                    g_str_equal,
+                                                    g_free,
+                                                    (GDestroyNotify) g_strfreev);
+  GVariantIter iter;
+  char *key;
+  GVariant *value;
+
+  g_variant_iter_init (&iter, available_effects_variant);
+
+  while (g_variant_iter_next (&iter, "{sv}", &key, &value))
+    {
+      g_autofree char *key_ref = g_steal_pointer (&key);
+      g_autoptr(GVariant) value_ref = g_steal_pointer (&value);
+      g_auto(GStrv) strv = (GStrv) g_variant_dup_strv (value_ref, NULL);
+
+      g_hash_table_insert (ht,
+                           (gpointer) g_steal_pointer (&key_ref),
+                           (gpointer) g_steal_pointer (&strv));
+    }
+
+  return g_steal_pointer (&ht);
+}
+
+void
+on_animations_dbus_client_surface_listed_available_effects (GObject      *source,
+                                                            GAsyncResult *result,
+                                                            gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GVariant) available_effects_variant = NULL;
+
+  if (!animations_dbus_animatable_surface_call_list_effects_finish (ANIMATIONS_DBUS_ANIMATABLE_SURFACE (source),
+                                                                    &available_effects_variant,
+                                                                    result,
+                                                                    &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+
+  g_task_return_pointer (task,
+                         available_effects_variant_to_hash_table (available_effects_variant),
+                         (GDestroyNotify) g_hash_table_unref);
+}
+
+
+void
+animations_dbus_client_surface_list_available_effects_async (AnimationsDbusClientSurface *surface,
+                                                             GCancellable                *cancellable,
+                                                             GAsyncReadyCallback          callback,
+                                                             gpointer                     user_data)
+{
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (surface);
+  GTask *task = g_task_new (surface, cancellable, callback, user_data);
+
+  animations_dbus_animatable_surface_call_list_effects (ANIMATIONS_DBUS_ANIMATABLE_SURFACE (priv->proxy),
+                                                        cancellable,
+                                                        on_animations_dbus_client_surface_listed_available_effects,
+                                                        task);
+}
+
+/**
+ * animations_dbus_client_surface_list_available_effects:
+ * @surface: An #AnimationsDbusClientSurface
+ * @error: A #GError
+ *
+ * Synchronously get a listing of available effects for each event.
+ *
+ * Returns: (transfer container) (element-type utf8 GStrv): A #GHashTable mapping
+ *          event names to a list of possible animation names that can be used
+ *          when attaching effects to that event.
+ */
+GHashTable *
+animations_dbus_client_surface_list_available_effects (AnimationsDbusClientSurface  *surface,
+                                                       GError                      **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_surface_list_available_effects_async (surface,
+                                                               NULL,
+                                                               animations_dbus_got_async_func_result,
+                                                               &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_surface_list_available_effects_finish (surface,
+                                                                       g_steal_pointer (&result),
+                                                                       error);
+}
+
+gboolean
+animations_dbus_client_surface_detach_effect_finish (AnimationsDbusClientSurface  *client_surface G_GNUC_UNUSED,
+                                                     GAsyncResult                 *result,
+                                                     GError                      **error)
+{
+  g_autoptr(GTask) task = G_TASK (result);
+  return g_task_propagate_boolean (task, error);
+}
+
+static void
+on_animations_dbus_client_surface_detached_effect (GObject      *source G_GNUC_UNUSED,
+                                                   GAsyncResult *result,
+                                                   gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClientSurface *client_surface = ANIMATIONS_DBUS_CLIENT_SURFACE (g_task_get_task_data (task));
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (client_surface);
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_animatable_surface_call_detach_animation_effect_finish (priv->proxy,
+                                                                               result,
+                                                                               &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_task_return_boolean (task, TRUE);
+}
+
+void
+animations_dbus_client_surface_detach_effect_async (AnimationsDbusClientSurface *surface,
+                                                    const char                  *event,
+                                                    AnimationsDbusClientEffect  *effect,
+                                                    GCancellable                *cancellable,
+                                                    GAsyncReadyCallback          callback,
+                                                    gpointer                     user_data)
+{
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (surface);
+  GTask *task = g_task_new (surface, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, surface, NULL);
+
+  animations_dbus_animatable_surface_call_detach_animation_effect (priv->proxy,
+                                                                   event,
+                                                                   animations_dbus_client_effect_get_object_path (effect),
+                                                                   cancellable,
+                                                                   on_animations_dbus_client_surface_detached_effect,
+                                                                   task);
+}
+
+gboolean
+animations_dbus_client_surface_detach_effect (AnimationsDbusClientSurface  *surface,
+                                              const char                   *event,
+                                              AnimationsDbusClientEffect   *effect,
+                                              GError                      **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_surface_detach_effect_async (surface,
+                                                      event,
+                                                      effect,
+                                                      NULL,
+                                                      animations_dbus_got_async_func_result,
+                                                      &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_surface_detach_effect_finish (surface,
+                                                              g_steal_pointer (&result),
+                                                              error);
+}
+
+gboolean
+animations_dbus_client_surface_attach_effect_finish (AnimationsDbusClientSurface  *client_surface G_GNUC_UNUSED,
+                                                     GAsyncResult                 *result,
+                                                     GError                      **error)
+{
+  g_autoptr(GTask) task = G_TASK (result);
+  return g_task_propagate_boolean (task, error);
+}
+
+static void
+on_animations_dbus_client_surface_attached_effect (GObject      *source G_GNUC_UNUSED,
+                                                   GAsyncResult *result,
+                                                   gpointer      user_data)
+{
+  GTask *task = G_TASK (user_data);
+  AnimationsDbusClientSurface *client_surface = ANIMATIONS_DBUS_CLIENT_SURFACE (g_task_get_task_data (task));
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (client_surface);
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_animatable_surface_call_attach_animation_effect_finish (priv->proxy,
+                                                                               result,
+                                                                               &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_task_return_boolean (task, TRUE);
+}
+
+void
+animations_dbus_client_surface_attach_effect_async (AnimationsDbusClientSurface *surface,
+                                                    const char                  *event,
+                                                    AnimationsDbusClientEffect  *effect,
+                                                    GCancellable                *cancellable,
+                                                    GAsyncReadyCallback          callback,
+                                                    gpointer                     user_data)
+{
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (surface);
+  GTask *task = g_task_new (surface, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, surface, NULL);
+
+  animations_dbus_animatable_surface_call_attach_animation_effect (priv->proxy,
+                                                                   event,
+                                                                   animations_dbus_client_effect_get_object_path (effect),
+                                                                   cancellable,
+                                                                   on_animations_dbus_client_surface_attached_effect,
+                                                                   task);
+}
+
+gboolean
+animations_dbus_client_surface_attach_effect (AnimationsDbusClientSurface  *surface,
+                                              const char                   *event,
+                                              AnimationsDbusClientEffect   *effect,
+                                              GError                      **error)
+{
+  g_autoptr(GMainContextPopDefault) context = animations_dbus_main_context_new_default ();
+  g_autoptr(GAsyncResult) result = NULL;
+
+  animations_dbus_client_surface_attach_effect_async (surface,
+                                                      event,
+                                                      effect,
+                                                      NULL,
+                                                      animations_dbus_got_async_func_result,
+                                                      &result);
+
+  while (result == NULL)
+    g_main_context_iteration (context, TRUE);
+
+  return animations_dbus_client_surface_attach_effect_finish (surface,
+                                                              g_steal_pointer (&result),
+                                                              error);
+}
+
+static void
+animations_dbus_client_surface_set_property (GObject      *object,
+                                             guint         prop_id,
+                                             const GValue *value,
+                                             GParamSpec   *pspec)
+{
+  AnimationsDbusClientSurface *client_surface = ANIMATIONS_DBUS_CLIENT_SURFACE (object);
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (client_surface);
+
+  switch (prop_id)
+    {
+    case PROP_PROXY:
+      priv->proxy = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_surface_get_property (GObject      *object,
+                                             unsigned int  prop_id,
+                                             GValue       *value,
+                                             GParamSpec   *pspec)
+{
+  AnimationsDbusClientSurface *client_surface = ANIMATIONS_DBUS_CLIENT_SURFACE (object);
+  AnimationsDbusClientSurfacePrivate *priv =
+    animations_dbus_client_surface_get_instance_private (client_surface);
+
+  switch (prop_id)
+    {
+    case PROP_PROXY:
+      g_value_set_object (value, priv->proxy);
+      break;
+    case PROP_TITLE:
+      g_value_set_string (value,
+                          animations_dbus_animatable_surface_get_title (ANIMATIONS_DBUS_ANIMATABLE_SURFACE (priv->proxy)));
+      break;
+    case PROP_GEOMETRY:
+      g_value_set_variant (value,
+                           animations_dbus_animatable_surface_get_geometry (ANIMATIONS_DBUS_ANIMATABLE_SURFACE (priv->proxy)));
+      break;
+    case PROP_EFFECTS:
+      g_value_set_variant (value,
+                           animations_dbus_animatable_surface_get_effects (ANIMATIONS_DBUS_ANIMATABLE_SURFACE (priv->proxy)));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_client_surface_dispose (GObject *object)
+{
+  AnimationsDbusClientSurface *client = ANIMATIONS_DBUS_CLIENT_SURFACE (object);
+  AnimationsDbusClientSurfacePrivate *priv = animations_dbus_client_surface_get_instance_private (client);
+
+  g_clear_object (&priv->proxy);
+
+  G_OBJECT_CLASS (animations_dbus_client_surface_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_client_surface_init (AnimationsDbusClientSurface *client G_GNUC_UNUSED)
+{
+}
+
+static void
+animations_dbus_client_surface_class_init (AnimationsDbusClientSurfaceClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = animations_dbus_client_surface_set_property;
+  object_class->get_property = animations_dbus_client_surface_get_property;
+  object_class->dispose = animations_dbus_client_surface_dispose;
+
+  animations_dbus_client_surface_properties[PROP_PROXY] =
+    g_param_spec_object ("proxy",
+                         "Proxy",
+                         "The DBus proxy for this animatable surface",
+                         ANIMATIONS_DBUS_TYPE_ANIMATABLE_SURFACE,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  animations_dbus_client_surface_properties[PROP_TITLE] =
+    g_param_spec_string ("title",
+                         "Title",
+                         "The title for this surface",
+                         "",
+                         G_PARAM_READABLE);
+
+  animations_dbus_client_surface_properties[PROP_GEOMETRY] =
+    g_param_spec_variant ("geometry",
+                          "Geometry",
+                          "The geometry for this surface",
+                          G_VARIANT_TYPE ("(iiii)"),
+                          g_variant_new ("(iiii)", 0, 0, 1, 1),
+                          G_PARAM_READABLE);
+
+  animations_dbus_client_surface_properties[PROP_EFFECTS] =
+    g_param_spec_variant ("effects",
+                          "Effects",
+                          "A dictionary of effects for each event on this surface",
+                          G_VARIANT_TYPE ("a{sv}"),
+                          g_variant_dict_end (g_variant_dict_new (NULL)),
+                          G_PARAM_READABLE);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     animations_dbus_client_surface_properties);
+}
+
+AnimationsDbusClientSurface *
+animations_dbus_client_surface_new_for_proxy (AnimationsDbusAnimatableSurface *surface_proxy)
+{
+  return g_object_new (ANIMATIONS_DBUS_TYPE_CLIENT_SURFACE,
+                       "proxy", surface_proxy,
+                       NULL);
+}

--- a/animations-dbus/animations-dbus-client-surface.h
+++ b/animations-dbus/animations-dbus-client-surface.h
@@ -1,0 +1,85 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib.h>
+
+#include <animations-dbus-objects.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_CLIENT_SURFACE animations_dbus_client_surface_get_type ()
+G_DECLARE_FINAL_TYPE (AnimationsDbusClientSurface, animations_dbus_client_surface, ANIMATIONS_DBUS, CLIENT_SURFACE, GObject)
+
+gboolean animations_dbus_client_surface_attach_effect_finish (AnimationsDbusClientSurface  *client_surface ,
+                                                              GAsyncResult                 *result,
+                                                              GError                      **error);
+
+void animations_dbus_client_surface_attach_effect_async (AnimationsDbusClientSurface *surface,
+                                                         const char                  *event,
+                                                         AnimationsDbusClientEffect  *effect,
+                                                         GCancellable                *cancellable,
+                                                         GAsyncReadyCallback          callback,
+                                                         gpointer                     user_data);
+
+gboolean
+animations_dbus_client_surface_attach_effect (AnimationsDbusClientSurface  *surface,
+                                              const char                   *event,
+                                              AnimationsDbusClientEffect   *effect,
+                                              GError                      **error);
+
+gboolean
+animations_dbus_client_surface_detach_effect_finish (AnimationsDbusClientSurface  *client_surface,
+                                                     GAsyncResult                 *result,
+                                                     GError                      **error);
+
+void animations_dbus_client_surface_detach_effect_async (AnimationsDbusClientSurface *surface,
+                                                         const char                  *event,
+                                                         AnimationsDbusClientEffect  *effect,
+                                                         GCancellable                *cancellable,
+                                                         GAsyncReadyCallback          callback,
+                                                         gpointer                     user_data);
+
+gboolean
+animations_dbus_client_surface_detach_effect (AnimationsDbusClientSurface  *surface,
+                                              const char                   *event,
+                                              AnimationsDbusClientEffect   *effect,
+                                              GError                      **error);
+
+GHashTable *
+animations_dbus_client_surface_list_available_effects_finish (AnimationsDbusClientSurface  *surface,
+                                                              GAsyncResult                 *result,
+                                                              GError                      **error);
+
+void animations_dbus_client_surface_list_available_effects_async (AnimationsDbusClientSurface *surface,
+                                                                  GCancellable                *cancellable,
+                                                                  GAsyncReadyCallback          callback,
+                                                                  gpointer                     user_data);
+
+GHashTable *
+animations_dbus_client_surface_list_available_effects (AnimationsDbusClientSurface  *surface,
+                                                       GError                      **error);
+
+AnimationsDbusClientSurface * animations_dbus_client_surface_new_for_proxy (AnimationsDbusAnimatableSurface *proxy);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-client.h
+++ b/animations-dbus/animations-dbus-client.h
@@ -1,0 +1,39 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_CLIENT_H
+
+#include <animations-dbus-version.h>
+
+#include <animations-dbus-client-effect.h>
+#include <animations-dbus-client-object.h>
+#include <animations-dbus-client-surface.h>
+#include <animations-dbus-errors.h>
+#include <animations-dbus-objects.h>
+
+#undef _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_CLIENT_H
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-errors.c
+++ b/animations-dbus/animations-dbus-errors.c
@@ -1,0 +1,49 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-errors.h"
+
+static const GDBusErrorEntry animations_dbus_error_entries[] =
+{
+  { ANIMATIONS_DBUS_ERROR_SERVER_SURFACE_NOT_FOUND, "com.endlessm.Libanimation.SurfaceNotFound" },
+  { ANIMATIONS_DBUS_ERROR_NAME_ALREADY_REGISTERED, "com.endlessm.Libanimation.NameAlreadyRegistered" },
+  { ANIMATIONS_DBUS_ERROR_CONNECTION_FAILED, "com.endlessm.Libanimation.ConnectionFailed" },
+  { ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION, "com.endlessm.Libanimation.NoSuchAnimation" },
+  { ANIMATIONS_DBUS_ERROR_INVALID_SETTING, "com.endlessm.Libanimation.InvalidSetting" },
+  { ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_SURFACE,
+    "com.endlessm.Libanimation.UnsupportedEventForAnimationSurface" },
+  { ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_EFFECT,
+    "com.endlessm.Libanimation.UnsupportedEventForAnimationEffect" },
+  { ANIMATIONS_DBUS_ERROR_INTERNAL_ERROR, "com.endlessm.Libanimation.InternalError" }
+};
+
+GQuark
+animations_dbus_error_quark (void)
+{
+  static volatile gsize quark_volatile = 0;
+  g_dbus_error_register_error_domain ("animation-dbus-error-quark",
+                                      &quark_volatile,
+                                      animations_dbus_error_entries,
+                                      G_N_ELEMENTS (animations_dbus_error_entries));
+
+  return (GQuark) quark_volatile;
+}

--- a/animations-dbus/animations-dbus-errors.h
+++ b/animations-dbus/animations-dbus-errors.h
@@ -1,0 +1,58 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/**
+ * AnimationsDbusError:
+ * @ANIMATIONS_DBUS_ERROR_SERVER_SURFACE_NOT_FOUND: The referred to surface pointer
+ *                                                  was not found
+ * @ANIMATIONS_DBUS_ERROR_NAME_ALREADY_REGISTERED: Client name was already registered
+ * @ANIMATIONS_DBUS_ERROR_CONNECTION_FAILED: Connection to the bus failed
+ * @ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION: No such animation at object path
+ * @ANIMATIONS_DBUS_ERROR_INVALID_SETTING: Invalid setting configuration
+ * @ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_EFFECT: The animation effect
+ *                                                                being attached does not
+ *                                                                support this event.
+ * @ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_SURFACE: The surface does not
+ *                                                                 support this event.
+ * @ANIMATIONS_DBUS_ERROR_INTERNAL_ERROR: Unrecoverable internal error
+ *
+ * Error enumeration for domain related errors.
+ */
+typedef enum {
+  ANIMATIONS_DBUS_ERROR_SERVER_SURFACE_NOT_FOUND,
+  ANIMATIONS_DBUS_ERROR_NAME_ALREADY_REGISTERED,
+  ANIMATIONS_DBUS_ERROR_CONNECTION_FAILED,
+  ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+  ANIMATIONS_DBUS_ERROR_INVALID_SETTING,
+  ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_EFFECT,
+  ANIMATIONS_DBUS_ERROR_UNSUPPORTED_EVENT_FOR_ANIMATION_SURFACE,
+  ANIMATIONS_DBUS_ERROR_INTERNAL_ERROR
+} AnimationsDbusError;
+
+#define ANIMATIONS_DBUS_ERROR animations_dbus_error_quark ()
+GQuark animations_dbus_error_quark (void);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-main-context-private.c
+++ b/animations-dbus/animations-dbus-main-context-private.c
@@ -1,0 +1,31 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include "animations-dbus-main-context-private.h"
+
+void
+animations_dbus_got_async_func_result (GObject      *source G_GNUC_UNUSED,
+                                       GAsyncResult *result,
+                                       gpointer      user_data)
+{
+  GAsyncResult **out_result = user_data;
+
+  *out_result = result;
+}

--- a/animations-dbus/animations-dbus-main-context-private.h
+++ b/animations-dbus/animations-dbus-main-context-private.h
@@ -1,0 +1,51 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+/* Adapted from flatpak-utils-private.h */
+typedef GMainContext GMainContextPopDefault;
+static inline void
+animations_dbus_main_context_pop_default_destroy (gpointer p)
+{
+  GMainContext *main_context = p;
+
+  if (main_context)
+    g_main_context_pop_thread_default (main_context);
+}
+
+static inline GMainContextPopDefault *
+animations_dbus_main_context_new_default (void)
+{
+  GMainContext *main_context = g_main_context_new ();
+
+  g_main_context_push_thread_default (main_context);
+  return main_context;
+}
+
+void animations_dbus_got_async_func_result (GObject      *source,
+                                            GAsyncResult *result,
+                                            gpointer      user_data);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GMainContextPopDefault, animations_dbus_main_context_pop_default_destroy)

--- a/animations-dbus/animations-dbus-server-animation-manager.c
+++ b/animations-dbus/animations-dbus-server-animation-manager.c
@@ -1,0 +1,404 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-errors.h"
+#include "animations-dbus-objects.h"
+#include "animations-dbus-server-animation-manager.h"
+#include "animations-dbus-server-effect.h"
+#include "animations-dbus-server-object.h"
+#include "animations-dbus-server-surface.h"
+
+struct _AnimationsDbusServerAnimationManager
+{
+  AnimationsDbusAnimationManagerSkeleton parent_instance;
+};
+
+typedef struct _AnimationsDbusServerAnimationManagerPrivate
+{
+  GDBusConnection                *connection;
+  AnimationsDbusServer           *server;
+  AnimationsDbusServerEffectFactory *effect_factory;
+
+  GHashTable *animation_effects;  /* (key-type: guint) (value-type: AnimationsDbusServerEffect) */
+  guint       animation_effect_serial;
+} AnimationsDbusServerAnimationManagerPrivate;
+
+static void animations_dbus_animation_manager_interface_init (AnimationsDbusAnimationManagerIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (AnimationsDbusServerAnimationManager,
+                         animations_dbus_server_animation_manager,
+                         ANIMATIONS_DBUS_TYPE_ANIMATION_MANAGER_SKELETON,
+                         G_ADD_PRIVATE (AnimationsDbusServerAnimationManager)
+                         G_IMPLEMENT_INTERFACE (ANIMATIONS_DBUS_TYPE_ANIMATION_MANAGER,
+                                                animations_dbus_animation_manager_interface_init))
+
+enum {
+  PROP_0,
+  PROP_CONNECTION,
+  PROP_SERVER,
+  PROP_EFFECT_FACTORY,
+  NPROPS
+};
+
+static GParamSpec *animations_dbus_server_animation_manager_props[NPROPS];
+
+/**
+ * animations_dbus_server_animation_manager_lookup_effect_by_id:
+ * @server_animation_manager: An #AnimationsDbusServerAnimationManager.
+ * @effect_id: The ID of the effect to find.
+ * @error: A #GError.
+ *
+ * Return an #AnimationsDbusServerEffect for the given ID on
+ * this #AnimationsDbusServerAnimationManager.
+ *
+ * Returns: (transfer none): An #AnimationsDbusServerEffect or %NULL with
+ *          @error set if one does not exist for that ID on this @animation_manager.
+ */
+AnimationsDbusServerEffect *
+animations_dbus_server_animation_manager_lookup_effect_by_id (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                              unsigned int                           effect_id,
+                                                              GError                               **error)
+{
+  AnimationsDbusServerAnimationManagerPrivate *priv =
+    animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+  AnimationsDbusServerEffect *server_animation_effect = NULL;
+
+  if (!g_hash_table_lookup_extended (priv->animation_effects,
+                                     GUINT_TO_POINTER (effect_id),
+                                     NULL,
+                                     (gpointer *) &server_animation_effect))
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+                   "No such animation with id %u",
+                   effect_id);
+      return NULL;
+    }
+
+  return server_animation_effect;
+}
+
+gboolean
+animations_dbus_server_animation_manager_export (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                 const char                            *object_path,
+                                                 GError                               **error)
+{
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+
+  return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (server_animation_manager),
+                                           priv->connection,
+                                           object_path,
+                                           error);
+}
+
+/**
+ * animations_dbus_server_animation_manager_create_effect:
+ * @server_animation_manager: An #AnimationsDbusServerAnimationManager.
+ * @title: The title of the effect.
+ * @name: The name of the effect to be created.
+ * @settings: A #GVariant of settings forming the initial settings payload.
+ * @error: A #GError.
+ *
+ * Create a #AnimationsDbusServerEffect for use by the
+ * server side. The effect will appear on the bus but
+ * will be managed by the caller.
+ *
+ * Returns: (transfer full): A #AnimationsDbusServerAnimationManager
+ * or %NULL with @error set in case of an error.
+ */
+AnimationsDbusServerEffect *
+animations_dbus_server_animation_manager_create_effect (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                        const char                            *title,
+                                                        const char                            *name,
+                                                        GVariant                              *settings,
+                                                        GError                               **error)
+{
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+  g_autoptr(GError) local_error = NULL;
+
+  g_autoptr(AnimationsDbusServerEffectBridge) effect_bridge =
+    animations_dbus_server_effect_factory_create_effect (priv->effect_factory,
+                                                         name,
+                                                         settings,
+                                                         error);
+
+  if (effect_bridge == NULL)
+    return NULL;
+
+  g_autoptr(AnimationsDbusServerEffect) animation_effect =
+    animations_dbus_server_effect_new (priv->connection,
+                                       effect_bridge,
+                                       title,
+                                       settings);
+  const char *animation_manager_object_path =
+    g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (server_animation_manager));
+  unsigned int available_serial = priv->animation_effect_serial++;
+  g_autofree char *animation_effect_object_path = g_strdup_printf ("%s/AnimationEffect/%u",
+                                                                   animation_manager_object_path,
+                                                                   available_serial);
+
+  if (!animations_dbus_server_effect_export (animation_effect,
+                                             animation_effect_object_path,
+                                             &local_error))
+    {
+      g_autofree char *printed_variant = g_variant_print (settings, TRUE);
+
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_INTERNAL_ERROR,
+                   "Could not register AnimationEffect "
+                   "for title '%s', name '%s', settings '%s': %s",
+                   title,
+                   name,
+                   printed_variant,
+                   local_error->message);
+      return NULL;
+    }
+
+  /* We always insert the AnimationsDbusServerAnimationEffect here since
+   * it should be visible and able to be looked up by clients on the bus. */
+  g_hash_table_insert (priv->animation_effects,
+                       GUINT_TO_POINTER (available_serial),
+                       g_object_ref (animation_effect));
+  return g_steal_pointer (&animation_effect);
+}
+
+typedef gpointer (*ElementMapFunc) (gpointer);
+
+static GPtrArray *
+pointer_array_map (GPtrArray      *src,
+                   ElementMapFunc  mapper,
+                   GDestroyNotify  dst_free_func)
+{
+  g_autoptr(GPtrArray) dst = g_ptr_array_new_full (src->len, dst_free_func);
+
+  for (size_t i = 0 ; i < src->len; ++i)
+    g_ptr_array_add (dst, mapper (g_ptr_array_index (src, i)));
+
+  return g_steal_pointer (&dst);
+}
+
+static gboolean
+animations_dbus_server_animation_manager_list_surfaces (AnimationsDbusAnimationManager *animation_manager,
+                                                        GDBusMethodInvocation          *invocation)
+{
+  AnimationsDbusServerAnimationManager *server_animation_manager =
+    ANIMATIONS_DBUS_SERVER_ANIMATION_MANAGER (animation_manager);
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+  GPtrArray *server_surfaces =
+    animations_dbus_server_list_surfaces (priv->server);
+  g_autoptr(GPtrArray) server_surface_object_paths =
+    pointer_array_map (server_surfaces,
+                       (ElementMapFunc) g_dbus_interface_skeleton_get_object_path,
+                       NULL);
+
+  g_ptr_array_add (server_surface_object_paths, NULL);
+
+  animations_dbus_animation_manager_complete_list_surfaces (animation_manager,
+                                                            invocation,
+                                                            (const char * const *) server_surface_object_paths->pdata);
+  return TRUE;
+}
+
+static gboolean
+animations_dbus_server_animation_manager_create_animation_effect (AnimationsDbusAnimationManager *animation_manager,
+                                                                  GDBusMethodInvocation          *invocation,
+                                                                  const char                     *title,
+                                                                  const char                     *name,
+                                                                  GVariant                       *settings)
+{
+  AnimationsDbusServerAnimationManager *server_animation_manager =
+    ANIMATIONS_DBUS_SERVER_ANIMATION_MANAGER (animation_manager);
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(AnimationsDbusServerEffect) server_effect =
+    animations_dbus_server_animation_manager_create_effect (server_animation_manager,
+                                                            title,
+                                                            name,
+                                                            settings,
+                                                            &local_error);
+
+  if (server_effect == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  animations_dbus_animation_manager_complete_create_animation_effect (animation_manager,
+                                                                      invocation,
+                                                                      g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (server_effect)));
+  return TRUE;
+}
+
+static void
+animations_dbus_animation_manager_interface_init (AnimationsDbusAnimationManagerIface *iface)
+{
+  iface->handle_list_surfaces = animations_dbus_server_animation_manager_list_surfaces;
+  iface->handle_create_animation_effect = animations_dbus_server_animation_manager_create_animation_effect;
+}
+
+static void
+animations_dbus_server_animation_manager_set_property (GObject      *object,
+                                                       guint         prop_id,
+                                                       const GValue *value,
+                                                       GParamSpec   *pspec)
+{
+  AnimationsDbusServerAnimationManager *server_animation_manager =
+    ANIMATIONS_DBUS_SERVER_ANIMATION_MANAGER (object);
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_clear_object (&priv->connection);
+      priv->connection = g_value_dup_object (value);
+      break;
+    case PROP_SERVER:
+      /* Observing reference, AnimationsDbusServer is expected to last
+       * longer than AnimationsDbusServerAnimationManager */
+      priv->server = g_value_get_object (value);
+      break;
+    case PROP_EFFECT_FACTORY:
+      priv->effect_factory = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_animation_manager_get_property (GObject    *object,
+                                                       guint       prop_id,
+                                                       GValue     *value,
+                                                       GParamSpec *pspec)
+{
+  AnimationsDbusServerAnimationManager *server_animation_manager =
+    ANIMATIONS_DBUS_SERVER_ANIMATION_MANAGER (object);
+  AnimationsDbusServerAnimationManagerPrivate *priv =
+    animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_value_set_object (value, priv->connection);
+      break;
+    case PROP_SERVER:
+      g_value_set_object (value, priv->server);
+      break;
+    case PROP_EFFECT_FACTORY:
+      g_value_set_object (value, priv->effect_factory);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+unref_hash_table_and_destroy_all_server_effect_values (GHashTable *animation_effects)
+{
+  GHashTableIter iter;
+  gpointer value;
+
+  /* Need to manually call animations_dbus_server_effect_destroy on each
+   * member of the hash table, since it is possible that language bindings
+   * could still have a reference on the effects. Calling
+   * animations_dbus_server_effect_destroy will ensure that the "destroy"
+   * signal gets emitted and the effect is detached from any surfaces. */
+  g_hash_table_iter_init (&iter, animation_effects);
+
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    animations_dbus_server_effect_destroy (ANIMATIONS_DBUS_SERVER_EFFECT (value));
+
+  g_hash_table_unref (animation_effects);
+}
+
+static void
+animations_dbus_server_animation_manager_finalize (GObject *object)
+{
+  AnimationsDbusServerAnimationManager *server_animation_manager = ANIMATIONS_DBUS_SERVER_ANIMATION_MANAGER (object);
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (server_animation_manager);
+
+  g_clear_pointer (&priv->animation_effects, unref_hash_table_and_destroy_all_server_effect_values);
+
+  G_OBJECT_CLASS (animations_dbus_server_animation_manager_parent_class)->finalize (object);
+}
+
+static void
+animations_dbus_server_animation_manager_init (AnimationsDbusServerAnimationManager *animation_manager)
+{
+  AnimationsDbusServerAnimationManagerPrivate *priv = animations_dbus_server_animation_manager_get_instance_private (animation_manager);
+
+  priv->animation_effects = g_hash_table_new_full (g_direct_hash,
+                                                   g_direct_equal,
+                                                   NULL,
+                                                   g_object_unref);
+}
+
+static void
+animations_dbus_server_animation_manager_class_init (AnimationsDbusServerAnimationManagerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = animations_dbus_server_animation_manager_get_property;
+  object_class->set_property = animations_dbus_server_animation_manager_set_property;
+  object_class->finalize = animations_dbus_server_animation_manager_finalize;
+
+  animations_dbus_server_animation_manager_props[PROP_CONNECTION] =
+    g_param_spec_object ("connection",
+                         "DBus Connection",
+                         "The DBus Connection this ServerAnimationManager is exported on",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  animations_dbus_server_animation_manager_props[PROP_SERVER] =
+    g_param_spec_object ("server",
+                         "Server",
+                         "The Server this ServerAnimationManager is for",
+                         ANIMATIONS_DBUS_TYPE_SERVER,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  animations_dbus_server_animation_manager_props[PROP_EFFECT_FACTORY] =
+    g_param_spec_object ("effect-factory",
+                         "Effect Factory",
+                         "The AnimationsDbusServerEffectFactory that will create the effects",
+                         ANIMATIONS_DBUS_TYPE_SERVER_EFFECT_FACTORY,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     animations_dbus_server_animation_manager_props);
+}
+
+AnimationsDbusServerAnimationManager *
+animations_dbus_server_animation_manager_new (GDBusConnection                   *connection,
+                                              AnimationsDbusServer              *server,
+                                              AnimationsDbusServerEffectFactory *effect_factory)
+{
+  return g_object_new (ANIMATIONS_DBUS_TYPE_SERVER_ANIMATION_MANAGER,
+                       "connection", connection,
+                       "server", server,
+                       "effect-factory", effect_factory,
+                       NULL);
+}

--- a/animations-dbus/animations-dbus-server-animation-manager.h
+++ b/animations-dbus/animations-dbus-server-animation-manager.h
@@ -1,0 +1,54 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include <animations-dbus-server-effect.h>
+#include <animations-dbus-server-effect-factory-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_ANIMATION_MANAGER animations_dbus_server_animation_manager_get_type ()
+
+AnimationsDbusServerEffect * animations_dbus_server_animation_manager_lookup_effect_by_id (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                                                           unsigned int                           effect_id,
+                                                                                           GError                               **error);
+
+
+AnimationsDbusServerEffect * animations_dbus_server_animation_manager_create_effect (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                                                     const char                            *title,
+                                                                                     const char                            *name,
+                                                                                     GVariant                              *settings,
+                                                                                     GError                               **error);
+
+gboolean animations_dbus_server_animation_manager_export (AnimationsDbusServerAnimationManager  *server_animation_manager,
+                                                          const char                            *object_path,
+                                                          GError                               **error);
+
+AnimationsDbusServerAnimationManager * animations_dbus_server_animation_manager_new (GDBusConnection                   *connection,
+                                                                                     AnimationsDbusServer              *server,
+                                                                                     AnimationsDbusServerEffectFactory *factory);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-effect-bridge-interface.c
+++ b/animations-dbus/animations-dbus-server-effect-bridge-interface.c
@@ -1,0 +1,43 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <glib.h>
+
+#include "animations-dbus-server-effect-bridge-interface.h"
+
+G_DEFINE_INTERFACE (AnimationsDbusServerEffectBridge,
+                    animations_dbus_server_effect_bridge,
+                    G_TYPE_OBJECT)
+
+static void
+animations_dbus_server_effect_bridge_default_init (AnimationsDbusServerEffectBridgeInterface *iface G_GNUC_UNUSED)
+{
+}
+
+const char *
+animations_dbus_server_effect_bridge_get_name (AnimationsDbusServerEffectBridge *self)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_EFFECT_BRIDGE (self), NULL);
+
+  AnimationsDbusServerEffectBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_EFFECT_BRIDGE_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->get_name != NULL, NULL);
+  return iface->get_name (self);
+}

--- a/animations-dbus/animations-dbus-server-effect-bridge-interface.h
+++ b/animations-dbus/animations-dbus-server-effect-bridge-interface.h
@@ -1,0 +1,40 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_EFFECT_BRIDGE animations_dbus_server_effect_bridge_get_type ()
+
+struct _AnimationsDbusServerEffectBridgeInterface
+{
+  GTypeInterface parent_iface;
+
+  const char * (*get_name) (AnimationsDbusServerEffectBridge *self);
+};
+
+const char * animations_dbus_server_effect_bridge_get_name (AnimationsDbusServerEffectBridge *self);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-effect-factory-interface.c
+++ b/animations-dbus/animations-dbus-server-effect-factory-interface.c
@@ -1,0 +1,64 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <glib.h>
+
+#include "animations-dbus-server-effect-bridge-interface.h"
+#include "animations-dbus-server-effect-factory-interface.h"
+
+G_DEFINE_INTERFACE (AnimationsDbusServerEffectFactory,
+                    animations_dbus_server_effect_factory,
+                    G_TYPE_OBJECT)
+
+static void
+animations_dbus_server_effect_factory_default_init (AnimationsDbusServerEffectFactoryInterface *iface G_GNUC_UNUSED)
+{
+}
+
+/**
+ * animations_dbus_server_effect_factory_create_effect:
+ * @self: An #AnimationsDbusServerEffectFactory.
+ * @effect: The effect name of the effect to create.
+ * @settings: The initial settings for this effect.
+ * @error: A #GError.
+ *
+ * Create the effect given by @effect with initial settings
+ * given by @settings. If @effect does not refer to a known
+ * effect, an error should be thrown. If @settings is not
+ * a valid settings variant for the effect, an error should be
+ * thrown.
+ *
+ * Returns: (transfer full): An #AnimationsDbusServerEffectBridge
+ *          representing the implementation for the effect or
+ *          %NULL with @error set in the case of an error.
+ */
+AnimationsDbusServerEffectBridge *
+animations_dbus_server_effect_factory_create_effect (AnimationsDbusServerEffectFactory  *self,
+                                                     const char                         *effect,
+                                                     GVariant                           *settings,
+                                                     GError                            **error)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_EFFECT_FACTORY (self), NULL);
+
+  AnimationsDbusServerEffectFactoryInterface *iface = ANIMATIONS_DBUS_SERVER_EFFECT_FACTORY_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->create_effect != NULL, NULL);
+  return iface->create_effect (self, effect, settings, error);
+}

--- a/animations-dbus/animations-dbus-server-effect-factory-interface.h
+++ b/animations-dbus/animations-dbus-server-effect-factory-interface.h
@@ -1,0 +1,47 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include <animations-dbus-server-effect-bridge-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_EFFECT_FACTORY animations_dbus_server_effect_factory_get_type ()
+
+struct _AnimationsDbusServerEffectFactoryInterface
+{
+  GTypeInterface parent_iface;
+
+  AnimationsDbusServerEffectBridge * (*create_effect) (AnimationsDbusServerEffectFactory  *self,
+                                                       const char                         *effect,
+                                                       GVariant                           *settings,
+                                                       GError                            **error);
+};
+
+AnimationsDbusServerEffectBridge * animations_dbus_server_effect_factory_create_effect (AnimationsDbusServerEffectFactory  *self,
+                                                                                        const char                         *effect,
+                                                                                        GVariant                           *settings,
+                                                                                        GError                            **error);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-effect.c
+++ b/animations-dbus/animations-dbus-server-effect.c
@@ -1,0 +1,367 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-errors.h"
+#include "animations-dbus-objects.h"
+#include "animations-dbus-server-effect.h"
+#include "animations-dbus-server-skeleton-properties.h"
+
+struct _AnimationsDbusServerEffect
+{
+  AnimationsDbusAnimationEffectSkeleton parent_instance;
+};
+
+typedef struct _AnimationsDbusServerEffectPrivate
+{
+  GDBusConnection                  *connection;
+  AnimationsDbusServerEffectBridge *effect_bridge;
+
+  char                             *title;
+  gboolean                          is_destroyed;
+} AnimationsDbusServerEffectPrivate;
+
+static void animations_dbus_animation_effect_interface_init (AnimationsDbusAnimationEffectIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (AnimationsDbusServerEffect,
+                         animations_dbus_server_effect,
+                         ANIMATIONS_DBUS_TYPE_ANIMATION_EFFECT_SKELETON,
+                         G_ADD_PRIVATE (AnimationsDbusServerEffect)
+                         G_IMPLEMENT_INTERFACE (ANIMATIONS_DBUS_TYPE_ANIMATION_EFFECT,
+                                                animations_dbus_animation_effect_interface_init))
+
+enum {
+  PROP_0,
+  PROP_CONNECTION,
+  PROP_BRIDGE,
+  PROP_NAME,
+  PROP_TITLE,
+  PROP_SETTINGS,
+  PROP_SCHEMA,
+  NPROPS
+};
+
+#define N_OWN_PROPS PROP_TITLE
+
+static GParamSpec *animations_dbus_server_effect_props[N_OWN_PROPS];
+
+enum {
+  SIGNAL_DESTROYED,
+  NSIGNALS
+};
+
+static unsigned int animations_dbus_server_effect_signals[NSIGNALS];
+
+gboolean
+animations_dbus_server_effect_export (AnimationsDbusServerEffect  *server_effect,
+                                      const char                  *object_path,
+                                      GError                     **error)
+{
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (server_effect),
+                                           priv->connection,
+                                           object_path,
+                                           error);
+}
+
+const char *
+animations_dbus_server_effect_get_title (AnimationsDbusServerEffect *server_effect)
+{
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  return priv->title;
+}
+
+/**
+ * animations_dbus_server_effect_destroy:
+ * @server_effect: An #AnimationsDbusServerEffect
+ *
+ * Cause the effect to be marked as "destroyed", which unexports it from
+ * the bus and emits the "destroy" signal, notifying interested listeners
+ * that the effect should be considered inert. It is safe to call this
+ * function multiple times, since the destroy signal emission and
+ * unexport process will only happen once.
+ */
+void
+animations_dbus_server_effect_destroy (AnimationsDbusServerEffect *server_effect)
+{
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  if (!priv->is_destroyed)
+    g_signal_emit (server_effect,
+                   animations_dbus_server_effect_signals[SIGNAL_DESTROYED],
+                   0);
+
+  /* XXX: Not ideal to have a check like this, but since animations_dbus_server_effect_destroy
+   *      can be called from animations_dbus_server_effect_dispose (where our reference count
+   *      would be zero), we need to have this check to avoid unexporting during the
+   *      dispose phase. The second check is to make sure we do not unexport twice,
+   *      which would raise a warning. */
+  if (G_IS_DBUS_INTERFACE_SKELETON (server_effect) &&
+      g_dbus_interface_skeleton_has_connection (G_DBUS_INTERFACE_SKELETON (server_effect),
+                                                priv->connection))
+    {
+      g_dbus_interface_skeleton_unexport_from_connection (G_DBUS_INTERFACE_SKELETON (server_effect),
+                                                          priv->connection);
+    }
+
+  priv->is_destroyed = TRUE;
+}
+
+static gboolean
+animations_dbus_server_effect_delete (AnimationsDbusAnimationEffect *animation_effect,
+                                      GDBusMethodInvocation         *invocation)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (animation_effect);
+
+  animations_dbus_server_effect_destroy (server_effect);
+  animations_dbus_animation_effect_complete_delete (animation_effect, invocation);
+
+  return TRUE;
+}
+
+static gboolean
+animations_dbus_server_effect_change_setting (AnimationsDbusAnimationEffect *animation_effect,
+                                              GDBusMethodInvocation         *invocation,
+                                              const char                    *name,
+                                              GVariant                      *value)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (animation_effect);
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+  g_autoptr(GVariant) unboxed = g_variant_ref_sink (g_variant_get_variant (value));
+  g_autoptr(GError) local_error = NULL;
+
+  if (!animations_dbus_set_property_from_variant (G_OBJECT (priv->effect_bridge),
+                                                  name,
+                                                  unboxed,
+                                                  &local_error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  const char *props[] = { "settings", NULL };
+  animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (animation_effect),
+                                                                   props);
+
+  animations_dbus_animation_effect_complete_change_setting (animation_effect, invocation);
+  return TRUE;
+}
+
+static void
+animations_dbus_animation_effect_interface_init (AnimationsDbusAnimationEffectIface *effect)
+{
+  effect->handle_delete = animations_dbus_server_effect_delete;
+  effect->handle_change_setting = animations_dbus_server_effect_change_setting;
+}
+
+static void
+animations_dbus_server_effect_set_property (GObject      *object,
+                                            guint         prop_id,
+                                            const GValue *value,
+                                            GParamSpec   *pspec)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (object);
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      priv->connection = g_value_dup_object (value);
+      break;
+    case PROP_BRIDGE:
+      priv->effect_bridge = g_value_dup_object (value);
+      break;
+    case PROP_TITLE:
+      priv->title = g_value_dup_string (value);
+      break;
+    case PROP_SETTINGS:
+      {
+        GVariant *settings = g_value_get_variant (value);
+        GVariantIter iter;
+        g_autoptr(GError) local_error = NULL;
+        char *key;
+        GVariant *value;
+
+        g_variant_iter_init (&iter, settings);
+        while (g_variant_iter_next (&iter, "{sv}", &key, &value))
+          {
+            g_autofree char *owned_key = g_steal_pointer (&key);
+            g_autoptr(GVariant) owned_value = g_steal_pointer (&value);
+            if (!animations_dbus_set_property_from_variant (G_OBJECT (priv->effect_bridge),
+                                                            owned_key,
+                                                            owned_value,
+                                                            &local_error))
+              {
+                g_autofree char *printed_value = g_variant_print (owned_value, TRUE);
+                g_warning ("Could not set property '%s' to value '%s' on animation '%s': %s",
+                           owned_key,
+                           printed_value,
+                           animations_dbus_server_effect_bridge_get_name (priv->effect_bridge),
+                           local_error->message);
+                continue;
+              }
+          }
+      }
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_effect_get_property (GObject    *object,
+                                            guint       prop_id,
+                                            GValue     *value,
+                                            GParamSpec *pspec)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (object);
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_value_set_object (value, priv->connection);
+      break;
+    case PROP_BRIDGE:
+      g_value_set_object (value, priv->effect_bridge);
+      break;
+    case PROP_TITLE:
+      g_value_set_string (value, priv->title);
+      break;
+    case PROP_NAME:
+      g_value_set_string (value, animations_dbus_server_effect_bridge_get_name (priv->effect_bridge));
+      break;
+    case PROP_SETTINGS:
+      g_value_take_variant (value,
+                           animations_dbus_serialize_properties_to_variant (G_OBJECT (priv->effect_bridge)));
+      break;
+    case PROP_SCHEMA:
+      g_value_take_variant (value,
+                           animations_dbus_serialize_pspecs_to_variant (G_OBJECT (priv->effect_bridge)));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_effect_dispose (GObject *object)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (object);
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  /* Destroy the effect and emit the destroy signal now which will
+   * cause the effect to be detached from any surfaces it is attached to. */
+  animations_dbus_server_effect_destroy (server_effect);
+
+  g_clear_object (&priv->effect_bridge);
+
+  G_OBJECT_CLASS (animations_dbus_server_effect_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_server_effect_finalize (GObject *object)
+{
+  AnimationsDbusServerEffect *server_effect = ANIMATIONS_DBUS_SERVER_EFFECT (object);
+  AnimationsDbusServerEffectPrivate *priv = animations_dbus_server_effect_get_instance_private (server_effect);
+
+  g_clear_pointer (&priv->title, g_free);
+
+  G_OBJECT_CLASS (animations_dbus_server_effect_parent_class)->finalize (object);
+}
+
+static void
+animations_dbus_server_effect_init (AnimationsDbusServerEffect *server_effect G_GNUC_UNUSED)
+{
+}
+
+static void
+animations_dbus_server_effect_class_init (AnimationsDbusServerEffectClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = animations_dbus_server_effect_get_property;
+  object_class->set_property = animations_dbus_server_effect_set_property;
+  object_class->dispose = animations_dbus_server_effect_dispose;
+  object_class->finalize = animations_dbus_server_effect_finalize;
+
+  animations_dbus_server_effect_props[PROP_CONNECTION] =
+    g_param_spec_object ("connection",
+                         "A GDBusConnection",
+                         "The GDBusConnection this effect is exported on",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+  animations_dbus_server_effect_props[PROP_BRIDGE] =
+    g_param_spec_object ("bridge",
+                         "An AnimationsDbusServerEffectBridge",
+                         "The AnimationsDbusServerEffectBridge that defines the effect",
+                         ANIMATIONS_DBUS_TYPE_SERVER_EFFECT_BRIDGE,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+  animations_dbus_server_effect_props[PROP_NAME] =
+    g_param_spec_string ("name",
+                         "Effect name",
+                         "The name of this effect",
+                         "",
+                         G_PARAM_READABLE);
+
+  g_object_class_install_properties (object_class,
+                                     N_OWN_PROPS,
+                                     animations_dbus_server_effect_props);
+
+  g_object_class_override_property (object_class,
+                                    PROP_TITLE,
+                                    "title");
+  g_object_class_override_property (object_class,
+                                    PROP_SETTINGS,
+                                    "settings");
+  g_object_class_override_property (object_class,
+                                    PROP_SCHEMA,
+                                    "schema");
+
+  animations_dbus_server_effect_signals[SIGNAL_DESTROYED] =
+    g_signal_new ("destroyed",
+                  G_TYPE_FROM_CLASS (object_class),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL,
+                  NULL,
+                  NULL,
+                  G_TYPE_NONE,
+                  0);
+}
+
+AnimationsDbusServerEffect *
+animations_dbus_server_effect_new (GDBusConnection                  *connection,
+                                   AnimationsDbusServerEffectBridge *bridge,
+                                   const char                       *title,
+                                   GVariant                         *settings)
+{
+  return g_object_new (ANIMATIONS_DBUS_TYPE_SERVER_EFFECT,
+                       "connection", connection,
+                       "bridge", bridge,
+                       "title", title,
+                       "settings", settings,
+                       NULL);
+}

--- a/animations-dbus/animations-dbus-server-effect.h
+++ b/animations-dbus/animations-dbus-server-effect.h
@@ -1,0 +1,49 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include <animations-dbus-objects.h>
+#include <animations-dbus-server-effect-bridge-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_EFFECT animations_dbus_server_effect_get_type ()
+
+
+gboolean animations_dbus_server_effect_export (AnimationsDbusServerEffect  *server_effect,
+                                               const char                  *object_path,
+                                               GError                     **error);
+
+const char * animations_dbus_server_effect_get_title (AnimationsDbusServerEffect *server_effect);
+
+void animations_dbus_server_effect_destroy (AnimationsDbusServerEffect *server_effect);
+
+AnimationsDbusServerEffect * animations_dbus_server_effect_new (GDBusConnection                  *connection,
+                                                                AnimationsDbusServerEffectBridge *bridge,
+                                                                const char                       *title,
+                                                                GVariant                         *settings);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-object.c
+++ b/animations-dbus/animations-dbus-server-object.c
@@ -1,0 +1,737 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-errors.h"
+#include "animations-dbus-objects.h"
+#include "animations-dbus-server-object.h"
+#include "animations-dbus-server-animation-manager.h"
+#include "animations-dbus-server-effect-factory-interface.h"
+#include "animations-dbus-server-surface.h"
+
+struct _AnimationsDbusServer
+{
+  GObject parent_instance;
+};
+
+typedef struct _AnimationsDbusServerPrivate
+{
+  GDBusConnection                         *connection;
+  guint                                    name_id;
+  AnimationsDbusConnectionManagerSkeleton *connection_manager_skeleton;
+
+  AnimationsDbusServerEffectFactory       *effect_factory;
+
+  /* One AnimationManager per client connection */
+  GHashTable *animation_manager_ids; /* (key-type: utf8) (value-type: guint) */
+  GHashTable *animation_managers;  /* (key-type: guint) (value-type: AnimationsDbusAnimationManager) */
+  guint       animation_manager_serial;
+
+  /* When a client calls RegisterClient and we create an
+   * AnimationManager for them, we also watch their owned
+   * bus name to see when it disappears. We can then tear
+   * down the corresponding AnimationManager for that bus
+   * name, ensuring a clean state when the client exits. */
+  GHashTable  *client_name_watches;
+
+  /* One AnimatableSurface per surface that is animatable.
+   *
+   * Add surfaces with animations_dbus_server_register_surface()
+   * and remove surfaces with animations_dbus_server_unregister_surface(). */
+  GPtrArray *animatable_surfaces; /* (element-type: AnimationsDbusServerSurface) */
+  guint      animatable_surface_serial;
+} AnimationsDbusServerPrivate;
+
+enum {
+  PROP_0,
+  PROP_CONNECTION,
+  PROP_EFFECT_FACTORY,
+  NPROPS
+};
+
+static GParamSpec *animations_dbus_server_props[NPROPS];
+
+enum {
+  SIGNAL_CLIENT_CONNECTED,
+  SIGNAL_CLIENT_DISCONNECTED,
+  NSIGNALS
+};
+
+static unsigned int animations_dbus_server_signals[NSIGNALS];
+
+static void animations_dbus_server_async_initable_interface_init (GAsyncInitableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (AnimationsDbusServer,
+                         animations_dbus_server,
+                         G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_ASYNC_INITABLE,
+                                                animations_dbus_server_async_initable_interface_init)
+                         G_ADD_PRIVATE (AnimationsDbusServer))
+
+/**
+ * animations_dbus_server_lookup_animation_effect_by_ids:
+ * @server: A #AnimationsDbusServer
+ * @animation_manager_id: The ID of the animation manager that the effect is on.
+ * @animation_effect_id: The ID of the effect.
+ * @error: A #GError
+ *
+ * Get the #AnimationsDbusServerEffect for the given @animation_manager_id and
+ * @animation_effect_id, or %NULL with @error set if either one does not exist.
+ *
+ * Returns: (transfer none): An #AnimationsDbusServerEffect if one exists for the given
+ *                           @animation_manager_id and @animation_effect_id or %NULL
+ *                           otherwise.
+ */
+AnimationsDbusServerEffect *
+animations_dbus_server_lookup_animation_effect_by_ids (AnimationsDbusServer  *server,
+                                                       unsigned int           animation_manager_id,
+                                                       unsigned int           animation_effect_id,
+                                                       GError               **error)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  const char *client_name = g_hash_table_lookup (priv->animation_manager_ids,
+                                                 GUINT_TO_POINTER (animation_manager_id));
+
+  if (client_name == NULL)
+    {
+      /* We use ANIMATIONS_DBUS_ERROR_NO_SUCH_EFFECT since that is
+       * basically mean to signify a bad object path when looking
+       * up an effect */
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+                   "No animation manager with id %u",
+                   animation_manager_id);
+      return NULL;
+    }
+
+  AnimationsDbusServerAnimationManager *animation_manager =
+    g_hash_table_lookup (priv->animation_managers,
+                         client_name);
+
+  g_assert (animation_manager != NULL);
+
+  return animations_dbus_server_animation_manager_lookup_effect_by_id (animation_manager,
+                                                                       animation_effect_id,
+                                                                       error);
+}
+
+/**
+ * animations_dbus_server_list_surfaces:
+ * @server: A #AnimationsDbusServer
+ *
+ * Get a #GPtrArray of surfaces that this #AnimationsDbusServer is tracking.
+ *
+ * Returns: (transfer none) (element-type AnimationsDbusServerSurface): A #GPtrArray
+ * of #AnimationsDbusServerSurface.
+ */
+GPtrArray *
+animations_dbus_server_list_surfaces (AnimationsDbusServer *server)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  return priv->animatable_surfaces;
+}
+
+#define ANIMATIONS_DBUS_ANIMATABLE_SURFACE_OBJECT_PATH_TEMPLATE "/com/endlessm/Libanimation/AnimatableSurface/%u"
+
+/**
+ * animations_dbus_server_register_surface:
+ * @server: A #AnimationsDbusServer.
+ * @bridge: An #AnimationsDbusServerSurfaceBridge.
+ * @error: A #GError
+ *
+ * Register a new surface, using @bridge to register effects and get properties
+ * on the underlying surface.
+ *
+ * Returns: (transfer full): An #AnimationsDbusServerSurface for the @title and
+ *          @geometry of the surface, or %NULL with @error set in case the surface
+ *          is not there.
+ */
+AnimationsDbusServerSurface *
+animations_dbus_server_register_surface (AnimationsDbusServer               *server,
+                                         AnimationsDbusServerSurfaceBridge  *bridge,
+                                         GError                            **error)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  g_autoptr(AnimationsDbusServerSurface) server_surface =
+    animations_dbus_server_surface_new (priv->connection,
+                                        server,
+                                        bridge);
+  unsigned int allocated_id = priv->animatable_surface_serial++;
+  g_autofree char *object_path = g_strdup_printf (ANIMATIONS_DBUS_ANIMATABLE_SURFACE_OBJECT_PATH_TEMPLATE, allocated_id);
+
+  if (!animations_dbus_server_surface_export (server_surface,
+                                              object_path,
+                                              error))
+    return NULL;
+
+  g_ptr_array_add (priv->animatable_surfaces, g_object_ref (server_surface));
+  return g_steal_pointer (&server_surface);
+}
+
+/**
+ * animations_dbus_server_unregister_surface:
+ * @server: A #AnimationsDbusServer
+ * @server_surface: The surface to unregister.
+ * @error: A #GError
+ *
+ * Unregister and unexport the given surface.
+ *
+ * Returns: %TRUE if the surface was unregistered and unexported correctly, %FALSE
+ *          with @error set otherwise.
+ */
+gboolean
+animations_dbus_server_unregister_surface (AnimationsDbusServer         *server,
+                                           AnimationsDbusServerSurface  *server_surface,
+                                           GError                      **error)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  if (!g_ptr_array_remove_fast (priv->animatable_surfaces, server_surface))
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_SERVER_SURFACE_NOT_FOUND,
+                   "Server surface %p was not found",
+                   (gpointer) server_surface);
+      return FALSE;
+    }
+
+  animations_dbus_server_surface_unexport (server_surface);
+  return TRUE;
+}
+
+#define LIBANIMATION_ANIMATION_MANAGER_OBJECT_PATH_TEMPLATE "/com/endlessm/Libanimation/AnimationManager/%u"
+
+/**
+ * animations_dbus_server_create_animation_manager:
+ * @server: An #AnimationsDbusServer.
+ * @error: A #GError.
+ *
+ * Create a #AnimationsDbusServerAnimationManager for use by the
+ * server side. The animation manager will appear on the bus but
+ * will be managed by the caller (for instance, there is no bus name
+ * that is being watched for the animation manager to be destroyed).
+ *
+ * Returns: (transfer full): A #AnimationsDbusServerAnimationManager
+ * or %NULL with @error set in case of an error.
+ */
+AnimationsDbusServerAnimationManager *
+animations_dbus_server_create_animation_manager (AnimationsDbusServer  *server,
+                                                 GError               **error)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  g_autoptr(AnimationsDbusServerAnimationManager) server_animation_manager =
+    animations_dbus_server_animation_manager_new (priv->connection,
+                                                  server,
+                                                  priv->effect_factory);
+
+  /* Need to be careful to use preincrement here as we will be
+   * doing a reverse lookup of this later and we can't have 0
+   * as 0 == NULL, which would indicate that an id was not found
+   * for a given client name */
+  unsigned int allocated_id = ++priv->animation_manager_serial;
+  g_autofree char *object_path = g_strdup_printf (LIBANIMATION_ANIMATION_MANAGER_OBJECT_PATH_TEMPLATE,
+                                                  allocated_id);
+
+  if (!animations_dbus_server_animation_manager_export (server_animation_manager,
+                                                        object_path,
+                                                        error))
+    return NULL;
+
+  /* Because the caller could be a user of the server library and not
+   * the server library itself
+   * (from on_animation_connection_manager_register_client), we don't
+   * register the newly created AnimationsDbusServerAnimationManager in
+   * the hash table, since it is up to the caller to keep track of its
+   * lifetime. */
+  return g_steal_pointer (&server_animation_manager);
+}
+
+static gboolean
+remove_if_value_strequal (gpointer key G_GNUC_UNUSED,
+                          gpointer value,
+                          gpointer user_data)
+{
+  return g_str_equal ((const char *) value, (const char *) user_data);
+}
+
+static void
+on_animation_manager_owner_name_lost (GDBusConnection *connection G_GNUC_UNUSED,
+                                      const char      *name,
+                                      gpointer         user_data)
+{
+  AnimationsDbusServer *server = user_data;
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  gpointer watch_id_ptr = NULL;
+
+  if (g_hash_table_lookup_extended (priv->client_name_watches,
+                                    name,
+                                    NULL,
+                                    (gpointer *) &watch_id_ptr))
+    {
+      unsigned int watch_id = GPOINTER_TO_UINT (watch_id_ptr);
+
+      g_bus_unwatch_name (watch_id);
+      g_hash_table_remove (priv->client_name_watches, name);
+      g_hash_table_remove (priv->animation_managers, name);
+
+      /* Need to do an O(N) lookup of ids names to remove the
+       * corresponding entry in the id table. We could also
+       * use an additional hash table here to avoid this cost
+       * but this seems like a simpler solution. */
+      unsigned int n_removed = g_hash_table_foreach_remove (priv->animation_manager_ids,
+                                                            remove_if_value_strequal,
+                                                            (gpointer) name);
+
+      g_assert (n_removed > 0);
+
+      g_signal_emit (server,
+                     animations_dbus_server_signals[SIGNAL_CLIENT_DISCONNECTED],
+                     0,
+                     name);
+    }
+}
+
+static gboolean
+on_animation_connection_manager_register_client (AnimationsDbusConnectionManager *connection_manager,
+                                                 GDBusMethodInvocation           *invocation,
+                                                 gpointer                         user_data)
+{
+  AnimationsDbusServer *server = user_data;
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  const char *sender = g_dbus_method_invocation_get_sender (invocation);
+  g_autoptr(GError) local_error = NULL;
+
+  if (g_hash_table_contains (priv->animation_managers, sender))
+    {
+      g_autofree char *message = g_strdup_printf ("Name '%s' already has an AnimationManager "
+                                                  "registered", sender);
+      g_dbus_method_invocation_return_error_literal (invocation,
+                                                     ANIMATIONS_DBUS_ERROR,
+                                                     ANIMATIONS_DBUS_ERROR_NAME_ALREADY_REGISTERED,
+                                                     message);
+      return TRUE;
+    }
+
+  g_autoptr(AnimationsDbusServerAnimationManager) server_animation_manager =
+    animations_dbus_server_create_animation_manager (server, &local_error);
+
+  if (server_animation_manager == NULL)
+    {
+      g_autofree char *message = g_strdup_printf ("Could not register AnimationManager "
+                                                  "for name '%s': %s",
+                                                  sender,
+                                                  local_error->message);
+      g_dbus_method_invocation_return_error_literal (invocation,
+                                                     ANIMATIONS_DBUS_ERROR,
+                                                     ANIMATIONS_DBUS_ERROR_INTERNAL_ERROR,
+                                                     message);
+      return TRUE;
+    }
+
+  /* Watch the name on the connection. If the name disappears, we can remove
+   * the animation manager and drop all of its associated effects. */
+  guint name_watch_id = g_bus_watch_name_on_connection (priv->connection,
+                                                        sender,
+                                                        G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                                        NULL,
+                                                        on_animation_manager_owner_name_lost,
+                                                        server,
+                                                        NULL);
+  g_hash_table_insert (priv->client_name_watches,
+                       g_strdup (sender),
+                       GINT_TO_POINTER (name_watch_id));
+  g_hash_table_insert (priv->animation_manager_ids,
+                       GINT_TO_POINTER (priv->animation_manager_serial),
+                       g_strdup (sender));
+  g_hash_table_insert (priv->animation_managers,
+                       g_strdup (sender),
+                       g_object_ref (server_animation_manager));
+
+  g_message ("Registering client '%s'", sender);
+
+  g_signal_emit (server,
+                 animations_dbus_server_signals[SIGNAL_CLIENT_CONNECTED],
+                 0,
+                 sender);
+
+  animations_dbus_connection_manager_complete_register_client (connection_manager,
+                                                               invocation,
+                                                               g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (server_animation_manager)));
+  return TRUE;
+}
+
+#define LIBANIMATION_DBUS_NAME "com.endlessm.Libanimation"
+#define LIBANIMATION_CONNECTION_MANAGER_OBJECT_PATH "/com/endlessm/Libanimation/ConnectionManager"
+
+static void
+on_got_session_bus_name (GDBusConnection *connection,
+                         const char      *name G_GNUC_UNUSED,
+                         gpointer         user_data)
+{
+  GTask *task = user_data;
+  g_autoptr(GError) local_error = NULL;
+  AnimationsDbusServer *server = g_task_get_task_data (task);
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  /* Now that we have the name, we can continue with constructing
+   * the connection manager. */
+  g_autoptr(AnimationsDbusConnectionManagerSkeleton) connection_manager_skeleton =
+    ANIMATIONS_DBUS_CONNECTION_MANAGER_SKELETON (animations_dbus_connection_manager_skeleton_new ());
+
+  if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (connection_manager_skeleton),
+                                         connection,
+                                         LIBANIMATION_CONNECTION_MANAGER_OBJECT_PATH,
+                                         &local_error))
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_signal_connect_object (connection_manager_skeleton,
+                           "handle-register-client",
+                           G_CALLBACK (on_animation_connection_manager_register_client),
+                           server,
+                           G_CONNECT_AFTER);
+
+  priv->connection_manager_skeleton = g_steal_pointer (&connection_manager_skeleton);
+  g_task_return_boolean (task, TRUE);
+}
+
+static void
+on_lost_session_bus_name (GDBusConnection *connection G_GNUC_UNUSED,
+                          const char      *name G_GNUC_UNUSED,
+                          gpointer         user_data)
+{
+  GTask *task = user_data;
+
+  /* Two possibilities - either the task has already completed
+   * and we lost the name for some other reason (maybe someone
+   * replaced us) or the task has not completed and we need to
+   * return an error to the caller to signify that async object
+   * initialization was not possible. */
+  if (g_task_get_completed (task))
+    {
+      /* Do nothing - the task will be unreferenced and
+       * cleaned up - someone else has replaced us. */
+      return;
+    }
+
+  /* Need to return an error to the caller */
+  g_task_return_new_error (task,
+                           ANIMATIONS_DBUS_ERROR,
+                           ANIMATIONS_DBUS_ERROR_CONNECTION_FAILED,
+                           "Couldn't get ownership of bus name " LIBANIMATION_DBUS_NAME);
+}
+
+static inline unsigned int
+attempt_to_own_session_bus_name (GDBusConnection *connection,
+                                 GTask           *task)
+{
+  return g_bus_own_name_on_connection (connection,
+                                       LIBANIMATION_DBUS_NAME,
+                                       G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
+                                       on_got_session_bus_name,
+                                       on_lost_session_bus_name,
+                                       task,
+                                       g_object_unref);
+}
+
+static void
+on_got_session_bus_connection (GObject      *object G_GNUC_UNUSED,
+                               GAsyncResult *result,
+                               gpointer      user_data)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GDBusConnection) connection = g_bus_get_finish (result, &local_error);
+  GTask *task = user_data;
+  AnimationsDbusServer *server = g_task_get_task_data (task);
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  if (connection == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  priv->connection = connection;
+
+  /* Now that we have the connection, own the bus name on
+   * behalf of the caller. */
+  priv->name_id = attempt_to_own_session_bus_name (priv->connection, task);
+}
+
+static gboolean
+animations_dbus_server_init_finish (GAsyncInitable  *initable,
+                                    GAsyncResult    *result,
+                                    GError         **error)
+{
+  g_return_val_if_fail (g_task_is_valid (result, initable), FALSE);
+
+  return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+static void
+animations_dbus_server_init_async (GAsyncInitable      *initable,
+                                   int                  io_priority G_GNUC_UNUSED,
+                                   GCancellable        *cancellable,
+                                   GAsyncReadyCallback  callback,
+                                   gpointer             user_data)
+{
+  AnimationsDbusServer *server = ANIMATIONS_DBUS_SERVER (initable);
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+  GTask *task = g_task_new (initable, cancellable, callback, user_data);
+
+  g_task_set_task_data (task, server, NULL);
+
+  if (priv->connection_manager_skeleton != NULL)
+    {
+      g_task_return_boolean (task, TRUE);
+      return;
+    }
+
+  /* The caller already passed us a connection that we can use,
+   * continue on to calling attempt_to_own_session_bus_name */
+  if (priv->connection != NULL)
+    {
+      priv->name_id = attempt_to_own_session_bus_name (priv->connection,
+                                                       task);
+      return;
+    }
+
+  g_bus_get (G_BUS_TYPE_SESSION,
+             cancellable,
+             on_got_session_bus_connection,
+             task);
+}
+
+static void
+animations_dbus_server_async_initable_interface_init (GAsyncInitableIface *iface)
+{
+  iface->init_async = animations_dbus_server_init_async;
+  iface->init_finish = animations_dbus_server_init_finish;
+}
+
+static void
+animations_dbus_server_set_property (GObject      *object,
+                                     guint         prop_id,
+                                     const GValue *value,
+                                     GParamSpec   *pspec)
+{
+  AnimationsDbusServer *server = ANIMATIONS_DBUS_SERVER (object);
+  AnimationsDbusServerPrivate *priv =
+    animations_dbus_server_get_instance_private (server);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      priv->connection = g_value_dup_object (value);
+      break;
+    case PROP_EFFECT_FACTORY:
+      priv->effect_factory = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_get_property (GObject    *object,
+                                     guint       prop_id,
+                                     GValue     *value,
+                                     GParamSpec *pspec)
+{
+  AnimationsDbusServer *server = ANIMATIONS_DBUS_SERVER (object);
+  AnimationsDbusServerPrivate *priv =
+    animations_dbus_server_get_instance_private (server);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_value_set_object (value, priv->connection);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_dispose (GObject *object)
+{
+  AnimationsDbusServer *server = ANIMATIONS_DBUS_SERVER (object);
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  g_clear_object (&priv->connection);
+  g_clear_object (&priv->connection_manager_skeleton);
+  g_clear_object (&priv->effect_factory);
+
+  g_clear_pointer (&priv->animation_managers, g_hash_table_unref);
+  g_clear_pointer (&priv->animatable_surfaces, g_ptr_array_unref);
+
+  G_OBJECT_CLASS (animations_dbus_server_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_server_finalize (GObject *object)
+{
+  AnimationsDbusServer *server = ANIMATIONS_DBUS_SERVER (object);
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  g_clear_pointer (&priv->client_name_watches, g_hash_table_unref);
+
+  if (priv->name_id != 0)
+    {
+      g_bus_unown_name (priv->name_id);
+      priv->name_id = 0;
+    }
+
+  G_OBJECT_CLASS (animations_dbus_server_parent_class)->finalize (object);
+}
+
+static void
+animations_dbus_server_init (AnimationsDbusServer *server)
+{
+  AnimationsDbusServerPrivate *priv = animations_dbus_server_get_instance_private (server);
+
+  priv->animatable_surfaces = g_ptr_array_new_with_free_func (g_object_unref);
+  priv->animation_managers = g_hash_table_new_full (g_str_hash,
+                                                    g_str_equal,
+                                                    g_free,
+                                                    g_object_unref);
+  priv->animation_manager_ids = g_hash_table_new_full (g_direct_hash,
+                                                       g_direct_equal,
+                                                       NULL,
+                                                       g_free);
+  priv->client_name_watches = g_hash_table_new_full (g_str_hash,
+                                                     g_str_equal,
+                                                     g_free,
+                                                     NULL);
+}
+
+static void
+animations_dbus_server_class_init (AnimationsDbusServerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = animations_dbus_server_get_property;
+  object_class->set_property = animations_dbus_server_set_property;
+  object_class->dispose = animations_dbus_server_dispose;
+  object_class->finalize = animations_dbus_server_finalize;
+
+  animations_dbus_server_props[PROP_CONNECTION] =
+    g_param_spec_object ("connection",
+                         "A GDBusConnection",
+                         "The GDBusConnection connecting this server to the session bus",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  animations_dbus_server_props[PROP_EFFECT_FACTORY] =
+    g_param_spec_object ("effect-factory",
+                         "An AnimationsDbusServerEffectFactory",
+                         "The AnimationsDbusServerEffectFactory that creates the animations",
+                         ANIMATIONS_DBUS_TYPE_SERVER_EFFECT_FACTORY,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     animations_dbus_server_props);
+
+  animations_dbus_server_signals[SIGNAL_CLIENT_CONNECTED] =
+    g_signal_new ("client-connected",
+                  G_TYPE_FROM_CLASS (object_class),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL,
+                  NULL,
+                  NULL,
+                  G_TYPE_NONE,
+                  1,
+                  G_TYPE_STRING);
+
+  animations_dbus_server_signals[SIGNAL_CLIENT_DISCONNECTED] =
+    g_signal_new ("client-disconnected",
+                  G_TYPE_FROM_CLASS (object_class),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL,
+                  NULL,
+                  NULL,
+                  G_TYPE_NONE,
+                  1,
+                  G_TYPE_STRING);
+}
+
+/**
+ * animations_dbus_server_new_finish:
+ * @source: The object passed to the #GAsyncReadyCallback.
+ * @result: A #GAsyncResult.
+ * @error: A #GError.
+ *
+ * Complete the call to animations_dbus_server_new_async.
+ *
+ * Returns: (transfer full): A new #AnimationsDbusServer or %NULL with
+ *          @error set in case of failure.
+ */
+AnimationsDbusServer *
+animations_dbus_server_new_finish (GObject       *source,
+                                   GAsyncResult  *result,
+                                   GError       **error)
+{
+  return ANIMATIONS_DBUS_SERVER (g_async_initable_new_finish (G_ASYNC_INITABLE (source),
+                                                              result,
+                                                              error));
+}
+
+void
+animations_dbus_server_new_async (AnimationsDbusServerEffectFactory *factory,
+                                  GCancellable                      *cancellable,
+                                  GAsyncReadyCallback                callback,
+                                  gpointer                           user_data)
+{
+  g_async_initable_new_async (ANIMATIONS_DBUS_TYPE_SERVER,
+                              G_PRIORITY_DEFAULT,
+                              cancellable,
+                              callback,
+                              user_data,
+                              "effect-factory", factory,
+                              NULL);
+}
+
+void
+animations_dbus_server_new_with_connection_async (AnimationsDbusServerEffectFactory *factory,
+                                                  GDBusConnection                   *connection,
+                                                  GCancellable                      *cancellable,
+                                                  GAsyncReadyCallback                callback,
+                                                  gpointer                           user_data)
+{
+  g_async_initable_new_async (ANIMATIONS_DBUS_TYPE_SERVER,
+                              G_PRIORITY_DEFAULT,
+                              cancellable,
+                              callback,
+                              user_data,
+                              "connection", connection,
+                              "effect-factory", factory,
+                              NULL);
+}

--- a/animations-dbus/animations-dbus-server-object.h
+++ b/animations-dbus/animations-dbus-server-object.h
@@ -1,0 +1,71 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib.h>
+
+#include <animations-dbus-objects.h>
+#include <animations-dbus-server-animation-manager.h>
+#include <animations-dbus-server-effect.h>
+#include <animations-dbus-server-effect-factory-interface.h>
+#include <animations-dbus-server-surface-bridge-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER animations_dbus_server_get_type ()
+
+GPtrArray * animations_dbus_server_list_surfaces (AnimationsDbusServer *server);
+
+AnimationsDbusServerEffect * animations_dbus_server_lookup_animation_effect_by_ids (AnimationsDbusServer  *server,
+                                                                                    unsigned int           animation_manager_id,
+                                                                                    unsigned int           animation_effect_id,
+                                                                                    GError               **error);
+
+AnimationsDbusServerSurface * animations_dbus_server_register_surface (AnimationsDbusServer               *server,
+                                                                       AnimationsDbusServerSurfaceBridge  *bridge,
+                                                                       GError                            **error);
+
+gboolean animations_dbus_server_unregister_surface (AnimationsDbusServer         *server,
+                                                    AnimationsDbusServerSurface  *server_surface,
+                                                    GError                      **error);
+
+AnimationsDbusServerAnimationManager * animations_dbus_server_create_animation_manager (AnimationsDbusServer  *server,
+                                                                                        GError               **error);
+
+AnimationsDbusServer * animations_dbus_server_new_finish (GObject       *source,
+                                                          GAsyncResult  *result,
+                                                          GError       **error);
+
+void animations_dbus_server_new_async (AnimationsDbusServerEffectFactory *factory,
+                                       GCancellable                      *cancellable,
+                                       GAsyncReadyCallback                callback,
+                                       gpointer                           user_data);
+
+void animations_dbus_server_new_with_connection_async (AnimationsDbusServerEffectFactory *factory,
+                                                       GDBusConnection                   *connection,
+                                                       GCancellable                      *cancellable,
+                                                       GAsyncReadyCallback                callback,
+                                                       gpointer                           user_data);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-skeleton-properties.c
+++ b/animations-dbus/animations-dbus-server-skeleton-properties.c
@@ -1,0 +1,383 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <glib.h>
+
+#include "animations-dbus-errors.h"
+#include "animations-dbus-server-skeleton-properties.h"
+
+static gpointer
+alloc_gtype (GType type)
+{
+  GType *ptr = g_new0 (GType, 1);
+
+  *ptr = type;
+  return ptr;
+}
+
+static gpointer
+value_type_to_variant_type_ht (gpointer data G_GNUC_UNUSED)
+{
+  GHashTable *ht = g_hash_table_new_full (g_int_hash, g_int_equal, g_free, NULL);
+
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_STRING),
+                       (gpointer) G_VARIANT_TYPE_STRING);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_STRV),
+                       (gpointer) G_VARIANT_TYPE_STRING_ARRAY);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_BOOLEAN),
+                       (gpointer) G_VARIANT_TYPE_BOOLEAN);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_UCHAR),
+                       (gpointer) G_VARIANT_TYPE_BYTE);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_INT),
+                       (gpointer) G_VARIANT_TYPE_INT32);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_UINT),
+                       (gpointer) G_VARIANT_TYPE_UINT32);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_INT64),
+                       (gpointer) G_VARIANT_TYPE_INT64);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_UINT64),
+                       (gpointer) G_VARIANT_TYPE_UINT64);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_DOUBLE),
+                       (gpointer) G_VARIANT_TYPE_DOUBLE);
+  g_hash_table_insert (ht,
+                       alloc_gtype (G_TYPE_VARIANT),
+                       (gpointer) G_VARIANT_TYPE_VARIANT);
+
+  return ht;
+}
+
+static const GVariantType *
+value_type_to_variant_type (GType type)
+{
+  static GOnce value_type_to_variant_type_once;
+
+  g_once (&value_type_to_variant_type_once, value_type_to_variant_type_ht, NULL);
+
+  const GVariantType *variant_type =
+    g_hash_table_lookup (value_type_to_variant_type_once.retval, &type);
+
+  if (variant_type == NULL)
+    g_warning ("Cannot convert from GType %lu to GVariantType", type);
+
+  return variant_type;
+}
+
+static GVariantDict *
+serialize_properties_to_variant_dict (GObject *object)
+{
+  unsigned int n_pspecs = 0;
+  GParamSpec **pspecs = g_object_class_list_properties (G_OBJECT_GET_CLASS (object), &n_pspecs);
+  g_autoptr(GVariantDict) vardict = g_variant_dict_new (NULL);
+
+  g_variant_dict_init (vardict, NULL);
+
+  for (unsigned int i = 0; i < n_pspecs; ++i)
+    {
+      g_auto(GValue) value = G_VALUE_INIT;
+
+      g_value_init (&value, pspecs[i]->value_type);
+      g_object_get_property (object, pspecs[i]->name, &value);
+
+      /* Non-floating reference */
+      g_autoptr(GVariant) variant =
+        g_dbus_gvalue_to_gvariant (&value, value_type_to_variant_type (pspecs[i]->value_type));
+      g_variant_dict_insert_value (vardict, pspecs[i]->name, variant);
+    }
+
+  g_free (pspecs);
+  return g_steal_pointer (&vardict);
+}
+
+GVariant *
+animations_dbus_serialize_properties_to_variant (GObject *object)
+{
+  g_autoptr(GVariantDict) vardict = serialize_properties_to_variant_dict (object);
+
+  return g_variant_dict_end (vardict);
+}
+
+static void
+get_range_variants_from_pspec (GParamSpec *pspec,
+                               GVariant   **out_min_variant,
+                               GVariant   **out_max_variant)
+{
+  g_assert (out_min_variant != NULL);
+  g_assert (out_max_variant != NULL);
+
+  *out_min_variant = NULL;
+  *out_max_variant = NULL;
+
+  switch (pspec->value_type)
+    {
+    case G_TYPE_INT:
+      {
+        GParamSpecInt *pspec_int = G_PARAM_SPEC_INT (pspec);
+        *out_min_variant = g_variant_new_int32 (pspec_int->minimum);
+        *out_max_variant = g_variant_new_int32 (pspec_int->maximum);
+      }
+      break;
+    case G_TYPE_UINT:
+      {
+        GParamSpecUInt *pspec_uint = G_PARAM_SPEC_UINT (pspec);
+        *out_min_variant = g_variant_new_uint32 (pspec_uint->minimum);
+        *out_max_variant = g_variant_new_uint32 (pspec_uint->maximum);
+      }
+      break;
+    case G_TYPE_LONG:
+      {
+        GParamSpecLong *pspec_long = G_PARAM_SPEC_LONG (pspec);
+        *out_min_variant = g_variant_new_int64 (pspec_long->minimum);
+        *out_max_variant = g_variant_new_int64 (pspec_long->maximum);
+      }
+      break;
+    case G_TYPE_ULONG:
+      {
+        GParamSpecULong *pspec_ulong = G_PARAM_SPEC_ULONG (pspec);
+        *out_min_variant = g_variant_new_uint64 (pspec_ulong->minimum);
+        *out_max_variant = g_variant_new_uint64 (pspec_ulong->maximum);
+      }
+      break;
+    case G_TYPE_FLOAT:
+      {
+        GParamSpecFloat *pspec_float = G_PARAM_SPEC_FLOAT (pspec);
+        *out_min_variant = g_variant_new_double (pspec_float->minimum);
+        *out_max_variant = g_variant_new_double (pspec_float->maximum);
+      }
+      break;
+    case G_TYPE_DOUBLE:
+      {
+        GParamSpecDouble *pspec_double = G_PARAM_SPEC_DOUBLE (pspec);
+        *out_min_variant = g_variant_new_double (pspec_double->minimum);
+        *out_max_variant = g_variant_new_double (pspec_double->maximum);
+      }
+      break;
+    }
+}
+
+GVariant *
+animations_dbus_serialize_pspecs_to_variant (GObject *object)
+{
+  unsigned int n_pspecs = 0;
+  GParamSpec **pspecs = g_object_class_list_properties (G_OBJECT_GET_CLASS (object), &n_pspecs);
+  g_auto(GVariantDict) vardict;
+
+  g_variant_dict_init (&vardict, NULL);
+
+  for (unsigned int i = 0; i < n_pspecs; ++i)
+    {
+      const GVariantType *prop_variant_type = value_type_to_variant_type (pspecs[i]->value_type);
+      GVariantDict prop_dict;
+
+      g_variant_dict_init (&prop_dict, NULL);
+      g_variant_dict_insert (&prop_dict,
+                             "type",
+                             "s",
+                             g_variant_type_peek_string (prop_variant_type));
+
+      const GValue *default_value =
+        g_param_spec_get_default_value (pspecs[i]);
+      /* Non-floating reference */
+      g_autoptr(GVariant) default_value_variant =
+        g_dbus_gvalue_to_gvariant (default_value, prop_variant_type);
+
+      g_variant_dict_insert_value (&prop_dict,
+                                   "default",
+                                   default_value_variant);
+
+      g_autoptr(GVariant) min_variant = NULL;
+      g_autoptr(GVariant) max_variant = NULL;
+      get_range_variants_from_pspec (pspecs[i], &min_variant, &max_variant);
+
+      /* Need to sink the floating reference on the outparam variants
+       * as they are owned by autoptr */
+      if (min_variant != NULL)
+        {
+          g_variant_ref_sink (min_variant);
+          g_variant_dict_insert_value (&prop_dict, "min", min_variant);
+        }
+
+      if (max_variant != NULL)
+        {
+          g_variant_ref_sink (max_variant);
+          g_variant_dict_insert_value (&prop_dict, "max", max_variant);
+        }
+
+      g_variant_dict_insert_value (&vardict,
+                                   pspecs[i]->name,
+                                   g_variant_dict_end (&prop_dict));
+    }
+
+  g_free (pspecs);
+  return g_variant_dict_end (&vardict);
+}
+
+gboolean
+animations_dbus_validate_property_from_variant (GObject     *object,
+                                                const char  *name,
+                                                GVariant    *variant,
+                                                GError     **error)
+{
+  GParamSpec *pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (object), name);
+
+  if (pspec == NULL)
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_INVALID_SETTING,
+                   "Animation does not have a setting name '%s'",
+                   name);
+      return FALSE;
+    }
+
+  g_auto(GValue) value = G_VALUE_INIT;
+  g_dbus_gvariant_to_gvalue (variant, &value);
+
+  /* Return value is whether modifying the value
+   * was necessary to ensure compliance with the
+   * constraints, we want to return an error in
+   * that case. */
+  if (g_param_value_validate (pspec, &value))
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_INVALID_SETTING,
+                   "Invalid value for setting '%s'",
+                   name);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+animations_dbus_set_property_from_variant (GObject     *object,
+                                           const char  *name,
+                                           GVariant    *variant,
+                                           GError     **error)
+{
+  if (!animations_dbus_validate_property_from_variant (object,
+                                                       name,
+                                                       variant,
+                                                       error))
+    return FALSE;
+
+  g_auto(GValue) value = G_VALUE_INIT;
+  g_dbus_gvariant_to_gvalue (variant, &value);
+
+  g_object_set_property (object, name, &value);
+  return TRUE;
+}
+
+/* XXX: Borrowing this struct from GDBus-Codegen is not ideal,
+ *      but it does not appear that there is a method
+ *      to get a D-Bus property name for a hyphenated name. */
+typedef struct
+{
+  GDBusPropertyInfo parent_struct;
+  const gchar *hyphen_name;
+  gboolean use_gvariant;
+} ExtendedGDBusPropertyInfo;
+
+static const char *
+lookup_dbus_prop_name_on_interface (GDBusInterfaceInfo *info,
+                                    const char         *name)
+{
+  GDBusPropertyInfo **properties = info->properties;
+
+  for (GDBusPropertyInfo **property_info_iter = properties;
+       *property_info_iter != NULL;
+       ++property_info_iter)
+    {
+      ExtendedGDBusPropertyInfo *extended_info = (ExtendedGDBusPropertyInfo *) *property_info_iter;
+
+      if (g_strcmp0 (name, extended_info->hyphen_name) == 0)
+        return (*property_info_iter)->name;
+    }
+
+  g_assert_not_reached ();
+  return NULL;
+}
+
+void
+animations_dbus_emit_properties_changed_for_skeleton_properties (GDBusInterfaceSkeleton *skeleton,
+                                                                 const char * const     *props)
+{
+  g_auto(GVariantBuilder) changed_builder;
+  g_auto(GVariantBuilder) invalidated_builder;
+
+  g_variant_builder_init (&changed_builder, G_VARIANT_TYPE("a{sv}"));
+  g_variant_builder_init (&invalidated_builder, G_VARIANT_TYPE("as"));
+
+  /* No work to do, return early */
+  if (*props == NULL)
+    return;
+
+  GObjectClass *object_class = G_OBJECT_GET_CLASS (G_OBJECT (skeleton));
+  GDBusInterfaceInfo *interface_info = g_dbus_interface_skeleton_get_info (skeleton);
+
+  for (const char * const *props_iter = props; *props_iter != NULL; ++props_iter)
+    {
+      GParamSpec *pspec = g_object_class_find_property (object_class, *props_iter);
+
+      g_assert (pspec != NULL);
+      g_auto(GValue) value = G_VALUE_INIT;
+
+      g_value_init (&value, pspec->value_type);
+      g_object_get_property (G_OBJECT (skeleton), *props_iter, &value);
+
+      /* Non-floating reference */
+      g_autoptr(GVariant) variant =
+        g_dbus_gvalue_to_gvariant (&value, value_type_to_variant_type (pspec->value_type));
+      g_variant_builder_add (&changed_builder,
+                             "{sv}",
+                             lookup_dbus_prop_name_on_interface (interface_info,
+                                                                 *props_iter),
+                             variant);
+    }
+
+  g_autoptr(GVariant) properties_changed_variant =
+    g_variant_ref_sink (g_variant_new ("(sa{sv}as)",
+                                       interface_info->name,
+                                       &changed_builder,
+                                       &invalidated_builder));
+  g_autoptr(GList) connections = g_dbus_interface_skeleton_get_connections (skeleton);
+
+  for (GList *l = connections; l != NULL; l = l->next)
+    {
+      GDBusConnection *connection = l->data;
+
+      g_dbus_connection_emit_signal (connection,
+                                     NULL,
+                                     g_dbus_interface_skeleton_get_object_path (skeleton),
+                                     "org.freedesktop.DBus.Properties",
+                                     "PropertiesChanged",
+                                     properties_changed_variant,
+                                     NULL);
+    }
+}
+

--- a/animations-dbus/animations-dbus-server-skeleton-properties.h
+++ b/animations-dbus/animations-dbus-server-skeleton-properties.h
@@ -1,0 +1,50 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+void animations_dbus_emit_properties_changed_for_skeleton_properties (GDBusInterfaceSkeleton *skeleton,
+                                                                      const char * const     *properties);
+
+gboolean
+animations_dbus_set_property_from_variant (GObject     *object,
+                                           const char  *name,
+                                           GVariant    *variant,
+                                           GError     **error);
+
+gboolean
+animations_dbus_validate_property_from_variant (GObject     *object,
+                                                const char  *name,
+                                                GVariant    *variant,
+                                                GError     **error);
+
+GVariant *
+animations_dbus_serialize_properties_to_variant (GObject *object);
+
+GVariant *
+animations_dbus_serialize_pspecs_to_variant (GObject *object);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-surface-attached-effect-interface.c
+++ b/animations-dbus/animations-dbus-server-surface-attached-effect-interface.c
@@ -18,16 +18,16 @@
  * - Sam Spilsbury <sam@endlessm.com>
  */
 
-#pragma once
-
 #include <glib.h>
 
-G_BEGIN_DECLS
+#include "animations-dbus-server-surface-attached-effect-interface.h"
 
-#define _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H
+G_DEFINE_INTERFACE (AnimationsDbusServerSurfaceAttachedEffect,
+                    animations_dbus_server_surface_attached_effect,
+                    G_TYPE_OBJECT)
 
-#include <animations-dbus-version.h>
+static void
+animations_dbus_server_surface_attached_effect_default_init (AnimationsDbusServerSurfaceAttachedEffectInterface *iface G_GNUC_UNUSED)
+{
+}
 
-#undef _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H
-
-G_END_DECLS

--- a/animations-dbus/animations-dbus-server-surface-attached-effect-interface.h
+++ b/animations-dbus/animations-dbus-server-surface-attached-effect-interface.h
@@ -1,0 +1,36 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_SURFACE_ATTACHED_EFFECT animations_dbus_server_surface_attached_effect_get_type ()
+
+struct _AnimationsDbusServerSurfaceAttachedEffectInterface
+{
+  GTypeInterface parent_iface;
+};
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-surface-bridge-interface.c
+++ b/animations-dbus/animations-dbus-server-surface-bridge-interface.c
@@ -1,0 +1,108 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <glib.h>
+
+#include "animations-dbus-server-surface-bridge-interface.h"
+
+G_DEFINE_INTERFACE (AnimationsDbusServerSurfaceBridge,
+                    animations_dbus_server_surface_bridge,
+                    G_TYPE_OBJECT)
+
+static void
+animations_dbus_server_surface_bridge_default_init (AnimationsDbusServerSurfaceBridgeInterface *iface G_GNUC_UNUSED)
+{
+}
+
+/**
+ * animations_dbus_server_surface_bridge_attach_effect:
+ * @self: An #AnimationsDbusServerSurfaceBridge
+ * @event: The event name to attach to
+ * @effect: The #AnimationsDbusServerEffect to be attached to this #AnimationsDbusServerSurfaceBridge
+ * @error: A #GError
+ *
+ * Attach an @effect to @self, creating the resources necessary to implement the effect
+ * on @self. The return value is an opaque interface representing an object
+ * containing those resources. If the resources cannot be created, %NULL is returned.
+ *
+ * Returns: (transfer full): A #AnimationsDbusServerSurfaceAttachedEffect representing the
+ *          resources to implement the effect on @self, or %NULL with @error set in case of
+ *          an error.
+ */
+AnimationsDbusServerSurfaceAttachedEffect *
+animations_dbus_server_surface_bridge_attach_effect (AnimationsDbusServerSurfaceBridge  *self,
+                                                     const char                         *event,
+                                                     AnimationsDbusServerEffect         *effect,
+                                                     GError                            **error)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_SURFACE_BRIDGE (self), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+  AnimationsDbusServerSurfaceBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_SURFACE_BRIDGE_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->attach_effect != NULL, NULL);
+  return iface->attach_effect (self, event, effect, error);
+}
+
+void
+animations_dbus_server_surface_bridge_detach_effect (AnimationsDbusServerSurfaceBridge         *self,
+                                                     const char                                *event,
+                                                     AnimationsDbusServerSurfaceAttachedEffect *effect)
+{
+  g_return_if_fail (ANIMATIONS_DBUS_IS_SERVER_SURFACE_BRIDGE (self));
+
+  AnimationsDbusServerSurfaceBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_SURFACE_BRIDGE_GET_IFACE (self);
+
+  g_return_if_fail (iface->detach_effect != NULL);
+  iface->detach_effect (self, event, effect);
+}
+
+const char *
+animations_dbus_server_surface_bridge_get_title (AnimationsDbusServerSurfaceBridge *self)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_SURFACE_BRIDGE (self), NULL);
+
+  AnimationsDbusServerSurfaceBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_SURFACE_BRIDGE_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->get_title != NULL, NULL);
+  return iface->get_title (self);
+}
+
+GVariant *
+animations_dbus_server_surface_bridge_get_geometry (AnimationsDbusServerSurfaceBridge *self)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_SURFACE_BRIDGE (self), NULL);
+
+  AnimationsDbusServerSurfaceBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_SURFACE_BRIDGE_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->get_geometry != NULL, NULL);
+  return iface->get_geometry (self);
+}
+
+GVariant *
+animations_dbus_server_surface_bridge_get_available_effects (AnimationsDbusServerSurfaceBridge *self)
+{
+  g_return_val_if_fail (ANIMATIONS_DBUS_IS_SERVER_SURFACE_BRIDGE (self), NULL);
+
+  AnimationsDbusServerSurfaceBridgeInterface *iface = ANIMATIONS_DBUS_SERVER_SURFACE_BRIDGE_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->get_available_effects != NULL, NULL);
+  return iface->get_available_effects (self);
+}

--- a/animations-dbus/animations-dbus-server-surface-bridge-interface.h
+++ b/animations-dbus/animations-dbus-server-surface-bridge-interface.h
@@ -1,0 +1,68 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include <animations-dbus-server-effect.h>
+#include <animations-dbus-server-surface-attached-effect-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_SURFACE_BRIDGE animations_dbus_server_surface_bridge_get_type ()
+
+struct _AnimationsDbusServerSurfaceBridgeInterface
+{
+  GTypeInterface parent_iface;
+
+  AnimationsDbusServerSurfaceAttachedEffect * (*attach_effect) (AnimationsDbusServerSurfaceBridge  *self,
+                                                                const char                         *event,
+                                                                AnimationsDbusServerEffect         *effect,
+                                                                GError                            **error);
+
+  void (*detach_effect) (AnimationsDbusServerSurfaceBridge         *self,
+                         const char                                *event,
+                         AnimationsDbusServerSurfaceAttachedEffect *attached_effect);
+
+  const char * (*get_title) (AnimationsDbusServerSurfaceBridge *self);
+
+  GVariant * (*get_geometry) (AnimationsDbusServerSurfaceBridge *self);
+
+  GVariant * (*get_available_effects) (AnimationsDbusServerSurfaceBridge *self);
+};
+
+AnimationsDbusServerSurfaceAttachedEffect * animations_dbus_server_surface_bridge_attach_effect (AnimationsDbusServerSurfaceBridge  *self,
+                                                                                                 const char                         *event,
+                                                                                                 AnimationsDbusServerEffect         *effect,
+                                                                                                 GError                            **error);
+
+void animations_dbus_server_surface_bridge_detach_effect (AnimationsDbusServerSurfaceBridge         *self,
+                                                          const char                                *event,
+                                                          AnimationsDbusServerSurfaceAttachedEffect *attached_effect);
+
+const char * animations_dbus_server_surface_bridge_get_title (AnimationsDbusServerSurfaceBridge *self);
+
+GVariant * animations_dbus_server_surface_bridge_get_geometry (AnimationsDbusServerSurfaceBridge *self);
+
+GVariant * animations_dbus_server_surface_bridge_get_available_effects (AnimationsDbusServerSurfaceBridge *self);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-surface.c
+++ b/animations-dbus/animations-dbus-server-surface.c
@@ -1,0 +1,733 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <gio/gio.h>
+
+#include "animations-dbus-errors.h"
+#include "animations-dbus-objects.h"
+#include "animations-dbus-server-effect.h"
+#include "animations-dbus-server-object.h"
+#include "animations-dbus-server-skeleton-properties.h"
+#include "animations-dbus-server-surface.h"
+#include "animations-dbus-server-surface-attached-effect-interface.h"
+#include "animations-dbus-server-surface-bridge-interface.h"
+
+struct _AnimationsDbusServerSurface
+{
+  AnimationsDbusAnimatableSurfaceSkeleton parent_instance;
+};
+
+typedef struct _AnimationsDbusServerSurfacePrivate
+{
+  GDBusConnection                   *connection;
+  AnimationsDbusServer              *server;
+  AnimationsDbusServerSurfaceBridge *bridge;
+
+  GHashTable *attached_effects_for_events;  /* (key-type: utf8) (value-type: GQueue) */
+} AnimationsDbusServerSurfacePrivate;
+
+static void animations_dbus_animatable_surface_interface_init (AnimationsDbusAnimatableSurfaceIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (AnimationsDbusServerSurface,
+                         animations_dbus_server_surface,
+                         ANIMATIONS_DBUS_TYPE_ANIMATABLE_SURFACE_SKELETON,
+                         G_ADD_PRIVATE (AnimationsDbusServerSurface)
+                         G_IMPLEMENT_INTERFACE (ANIMATIONS_DBUS_TYPE_ANIMATABLE_SURFACE,
+                                                animations_dbus_animatable_surface_interface_init))
+
+enum {
+  PROP_0,
+  PROP_CONNECTION,
+  PROP_SERVER,
+  PROP_BRIDGE,
+  PROP_TITLE,
+  PROP_GEOMETRY,
+  PROP_EFFECTS
+};
+
+#define N_OWN_PROPS PROP_TITLE
+
+static GParamSpec *animations_dbus_server_surface_props[N_OWN_PROPS];
+
+typedef struct {
+  AnimationsDbusServerEffect                *server_effect;
+  AnimationsDbusServerSurfaceAttachedEffect *attached_effect;
+} AttachedEffectInfo;
+
+AttachedEffectInfo *
+attached_effect_info_new (AnimationsDbusServerEffect                *server_effect,
+                          AnimationsDbusServerSurfaceAttachedEffect *attached_effect)
+{
+  AttachedEffectInfo *info = g_new0 (AttachedEffectInfo, 1);
+
+  info->server_effect = g_object_ref (server_effect);
+  info->attached_effect = g_object_ref (attached_effect);
+
+  return info;
+}
+
+void
+attached_effect_info_free (AttachedEffectInfo *info)
+{
+  g_clear_object (&info->server_effect);
+  g_clear_object (&info->attached_effect);
+
+  g_free (info);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (AttachedEffectInfo, attached_effect_info_free)
+
+static void
+animations_dbus_server_surface_detach_animation_effect_from_all_events (AnimationsDbusServerSurface *server_surface,
+                                                                        AnimationsDbusServerEffect  *server_animation_effect)
+{
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+  gpointer key, value;
+  GHashTableIter iter;
+
+  g_hash_table_iter_init (&iter, priv->attached_effects_for_events);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      const char *event = key;
+      GQueue *effects = value;
+      GList *link = g_queue_peek_head_link (effects);
+
+      for (; link != NULL; link = link->next)
+        {
+          AttachedEffectInfo *info = link->data;
+
+          if (info->server_effect == server_animation_effect)
+            {
+              animations_dbus_server_surface_bridge_detach_effect (priv->bridge,
+                                                                   event,
+                                                                   info->attached_effect);
+
+              /* Notify listeners that we've dettached the effect from this
+               * event and that the effects property has changed now. */
+              const char *props[] = { "effects", NULL };
+              animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                                               props);
+
+              g_queue_delete_link (effects, link);
+              attached_effect_info_free (info);
+              break;
+            }
+        }
+    }
+}
+
+static void
+on_server_animation_effect_destroyed (AnimationsDbusServerEffect *server_animation_effect,
+                                      gpointer                    user_data)
+{
+  AnimationsDbusServerSurface *server_surface = user_data;
+
+  animations_dbus_server_surface_detach_animation_effect_from_all_events (server_surface,
+                                                                          server_animation_effect);
+}
+
+typedef void (*QueuePushFunc) (GQueue *, gpointer);
+
+static gboolean
+animations_dbus_server_surface_attach_effect_with_queue_func (AnimationsDbusServerSurface  *server_surface,
+                                                              const char                   *event,
+                                                              AnimationsDbusServerEffect   *server_animation_effect,
+                                                              QueuePushFunc                 push_func,
+                                                              GError                      **error)
+{
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  g_assert (push_func != NULL);
+
+  /* Look for the event in the queue first to ensure that we don't
+   * try and attach the same effect twice. O(N) for the number of
+   * attached effects but N should be quite small. */
+  GQueue *attached_effects_for_event = g_hash_table_lookup (priv->attached_effects_for_events, event);
+
+  if (attached_effects_for_event == NULL)
+    {
+      attached_effects_for_event = g_queue_new ();
+
+      g_hash_table_insert (priv->attached_effects_for_events,
+                           g_strdup (event),
+                           attached_effects_for_event);
+    }
+
+  for (GList *link = g_queue_peek_head_link (attached_effects_for_event);
+       link != NULL;
+       link = link->next)
+    {
+      AttachedEffectInfo *info = link->data;
+
+      if (info->server_effect == server_animation_effect)
+        return TRUE;
+    }
+
+  /* Now create an AttachedEffect struct, which represents our attempt
+   * to attach this effect to the ServerSurfaceBridge. If the effect
+   * cannot be attached to the SurfaceSurfaceBridge, this function
+   * returns %NULL with @error set and we return accordingly. */
+  g_autoptr(AnimationsDbusServerSurfaceAttachedEffect) attached_effect =
+    animations_dbus_server_surface_bridge_attach_effect (priv->bridge,
+                                                         event,
+                                                         server_animation_effect,
+                                                         error);
+
+  if (attached_effect == NULL)
+    return FALSE;
+
+  push_func (attached_effects_for_event,
+             attached_effect_info_new (server_animation_effect,
+                                       attached_effect));
+
+  /* Notify listeners that we've attached the effect to this
+   * event and that the effects property has changed now. */
+  const char *props[] = { "effects", NULL };
+  animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                                   props);
+
+  /* Watch for the effect to be destroyed. When it is deleted
+   * we'll need to detach it from the surface too */
+  g_signal_connect_object (server_animation_effect,
+                           "destroyed",
+                           G_CALLBACK (on_server_animation_effect_destroyed),
+                           server_surface,
+                           G_CONNECT_AFTER);
+
+  return TRUE;
+}
+
+gboolean
+animations_dbus_server_surface_export (AnimationsDbusServerSurface  *server_surface,
+                                       const char                   *object_path,
+                                       GError                      **error)
+{
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                           priv->connection,
+                                           object_path,
+                                           error);
+}
+
+void
+animations_dbus_server_surface_unexport (AnimationsDbusServerSurface *server_surface)
+{
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+  g_dbus_interface_skeleton_unexport_from_connection (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                      priv->connection);
+}
+
+gboolean
+animations_dbus_server_surface_attach_animation_effect_with_server_priority (AnimationsDbusServerSurface  *server_surface,
+                                                                             const char                   *event,
+                                                                             AnimationsDbusServerEffect   *server_animation_effect,
+                                                                             GError                      **error)
+{
+  /* Other effects take priority over this one, since server effects
+   * can be overridden by the user. */
+  return animations_dbus_server_surface_attach_effect_with_queue_func (server_surface,
+                                                                       event,
+                                                                       server_animation_effect,
+                                                                       g_queue_push_tail,
+                                                                       error);
+}
+
+/**
+ * animations_dbus_server_surface_highest_priority_attached_effect_for_event:
+ * @server_surface: The #AnimationsDbusServerSurface with the attached effects.
+ * @event: The event to get the highest priority effect on.
+ *
+ * Check the attached effects for @event on @surface and get the highest priority
+ * effect, returning its #AnimationsDbusServerSurfaceAttachedEffect (private data
+ * for the effect).
+ *
+ * Returns: (transfer none): The #AnimationsDbusServerSurfaceAttachedEffect for the highest
+ *          priority effect on @surface for @event, or %NULL if no events are attached to
+ *          @effect.
+ */
+AnimationsDbusServerSurfaceAttachedEffect *
+animations_dbus_server_surface_highest_priority_attached_effect_for_event (AnimationsDbusServerSurface *server_surface,
+                                                                           const char                  *event)
+{
+  AnimationsDbusServerSurfacePrivate *priv =
+    animations_dbus_server_surface_get_instance_private (server_surface);
+  GQueue *attached_effects_for_event = g_hash_table_lookup (priv->attached_effects_for_events, event);
+
+  if (attached_effects_for_event)
+    {
+      AttachedEffectInfo *info = g_queue_peek_head (attached_effects_for_event);
+
+      if (info == NULL)
+        return NULL;
+
+      return info->attached_effect;
+    }
+
+  return NULL;
+}
+
+void
+animations_dbus_server_surface_emit_geometry_changed (AnimationsDbusServerSurface *server_surface)
+{
+  const char *props[] = { "geometry", NULL };
+
+  animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                                   props);
+}
+
+void
+animations_dbus_server_surface_emit_title_changed (AnimationsDbusServerSurface *server_surface)
+{
+  const char *props[] = { "title", NULL };
+
+  animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                                   props);
+}
+
+/* /com/endlessm/Libanimation/AnimationManager/N/AnimationEffect/M */
+#define EFFECT_PATH_EXPECTED_COMPONENTS 8
+#define EFFECT_PATH_ANIMATION_MANAGER_INDEX 5
+#define EFFECT_PATH_ANIMATION_EFFECT_INDEX 7
+
+static gboolean
+parse_effect_path (const char    *effect_path,
+                   unsigned int  *out_animation_manager_id,
+                   unsigned int  *out_animation_effect_id,
+                   GError       **error)
+{
+  g_return_val_if_fail (out_animation_manager_id != NULL, FALSE);
+  g_return_val_if_fail (out_animation_effect_id != NULL, FALSE);
+
+  g_auto(GStrv) effect_path_components = g_strsplit (effect_path, "/", 0);
+  unsigned int path_length = g_strv_length (effect_path_components);
+  guint64 animation_manager_id64 = 0;
+  guint64 animation_effect_id64 = 0;
+  g_autoptr(GError) local_error = NULL;
+
+  if (path_length != EFFECT_PATH_EXPECTED_COMPONENTS)
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+                   "Expected animation path '%s' to have %u components, but "
+                   "had %u components",
+                   effect_path,
+                   EFFECT_PATH_EXPECTED_COMPONENTS,
+                   path_length);
+      return FALSE;
+    }
+
+  if (!g_ascii_string_to_unsigned (effect_path_components[EFFECT_PATH_ANIMATION_MANAGER_INDEX],
+                                   10,
+                                   0,
+                                   G_MAXUINT,
+                                   &animation_manager_id64,
+                                   &local_error))
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+                   "Expected animation path component '%s' to be an "
+                   "unsigned integer: %s",
+                   effect_path_components[EFFECT_PATH_ANIMATION_MANAGER_INDEX],
+                   local_error->message);
+      return FALSE;
+    }
+
+  if (!g_ascii_string_to_unsigned (effect_path_components[EFFECT_PATH_ANIMATION_EFFECT_INDEX],
+                                   10,
+                                   0,
+                                   G_MAXUINT,
+                                   &animation_effect_id64,
+                                   &local_error))
+    {
+      g_set_error (error,
+                   ANIMATIONS_DBUS_ERROR,
+                   ANIMATIONS_DBUS_ERROR_NO_SUCH_ANIMATION,
+                   "Expected animation path component '%s' to be an "
+                   "unsigned integer: %s",
+                   effect_path_components[EFFECT_PATH_ANIMATION_EFFECT_INDEX],
+                   local_error->message);
+      return FALSE;
+    }
+
+  *out_animation_manager_id = (unsigned int) animation_manager_id64;
+  *out_animation_effect_id = (unsigned int) animation_effect_id64;
+
+  return TRUE;
+}
+
+static gboolean
+animations_dbus_server_surface_attach_animation_effect (AnimationsDbusAnimatableSurface *animatable_surface,
+                                                        GDBusMethodInvocation           *invocation,
+                                                        const char                      *event,
+                                                        const char                      *effect_path)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (animatable_surface);
+  AnimationsDbusServerSurfacePrivate *priv =
+    animations_dbus_server_surface_get_instance_private (server_surface);
+  unsigned int animation_manager_id = 0;
+  unsigned int animation_effect_id = 0;
+  g_autoptr(GError) local_error = NULL;
+
+  /* Validate that the passed in effect_path is a valid object path */
+  if (!parse_effect_path (effect_path,
+                          &animation_manager_id,
+                          &animation_effect_id,
+                          &local_error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  AnimationsDbusServerEffect *server_animation_effect =
+    animations_dbus_server_lookup_animation_effect_by_ids (priv->server,
+                                                           animation_manager_id,
+                                                           animation_effect_id,
+                                                           &local_error);
+
+  /* Insert the animation effect into the table */
+  if (server_animation_effect == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  /* Newly attached effects take priority over old ones */
+  if (!animations_dbus_server_surface_attach_effect_with_queue_func (server_surface,
+                                                                     event,
+                                                                     server_animation_effect,
+                                                                     g_queue_push_head,
+                                                                     &local_error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  animations_dbus_animatable_surface_complete_attach_animation_effect (animatable_surface,
+                                                                       invocation);
+  return TRUE;
+}
+
+static gboolean
+animations_dbus_server_surface_detach_animation_effect (AnimationsDbusAnimatableSurface *animatable_surface,
+                                                        GDBusMethodInvocation           *invocation,
+                                                        const char                      *event,
+                                                        const char                      *effect_path)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (animatable_surface);
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+  unsigned int animation_manager_id = 0;
+  unsigned int animation_effect_id = 0;
+  GQueue *attached_effects_for_events = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  /* Validate that the passed in effect_path is a valid object path */
+  if (!parse_effect_path (effect_path,
+                          &animation_manager_id,
+                          &animation_effect_id,
+                          &local_error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  AnimationsDbusServerEffect *server_animation_effect =
+    animations_dbus_server_lookup_animation_effect_by_ids (priv->server,
+                                                           animation_manager_id,
+                                                           animation_effect_id,
+                                                           &local_error);
+
+  /* Remove the animation effect from the table */
+  if (server_animation_effect == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation,
+                                              g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
+  attached_effects_for_events = g_hash_table_lookup (priv->attached_effects_for_events, event);
+
+  /* Not attached, do nothing */
+  if (attached_effects_for_events == NULL)
+    {
+      animations_dbus_animatable_surface_complete_detach_animation_effect (animatable_surface,
+                                                                           invocation);
+      return TRUE;
+    }
+
+  /* Search for the effect in the attached effects and remove it,
+   * also notifying the bridge that the effect is to be detached. */
+  for (GList *link = g_queue_peek_head_link (attached_effects_for_events);
+       link != NULL;
+       link = link->next)
+    {
+      AttachedEffectInfo *info = link->data;
+
+      if (info->server_effect == server_animation_effect)
+        {
+          animations_dbus_server_surface_bridge_detach_effect (priv->bridge,
+                                                               event,
+                                                               info->attached_effect);
+
+          /* Notify listeners that we've dettached the effect from this
+           * event and that the effects property has changed now. */
+          const char *props[] = { "effects", NULL };
+          animations_dbus_emit_properties_changed_for_skeleton_properties (G_DBUS_INTERFACE_SKELETON (server_surface),
+                                                                           props);
+
+          g_queue_delete_link (attached_effects_for_events, link);
+          attached_effect_info_free (info);
+          break;
+        }
+    }
+
+  animations_dbus_animatable_surface_complete_detach_animation_effect (animatable_surface,
+                                                                       invocation);
+  return TRUE;
+}
+
+static gboolean
+animations_dbus_server_surface_list_animation_effects (AnimationsDbusAnimatableSurface *animatable_surface,
+                                                       GDBusMethodInvocation           *invocation)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (animatable_surface);
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+  g_autoptr(GVariant) available_effects =
+    g_variant_ref_sink (animations_dbus_server_surface_bridge_get_available_effects (priv->bridge));
+
+  animations_dbus_animatable_surface_complete_list_effects (animatable_surface,
+                                                            invocation,
+                                                            available_effects);
+  return TRUE;
+}
+
+static void
+animations_dbus_animatable_surface_interface_init (AnimationsDbusAnimatableSurfaceIface *iface)
+{
+  iface->handle_attach_animation_effect = animations_dbus_server_surface_attach_animation_effect;
+  iface->handle_detach_animation_effect = animations_dbus_server_surface_detach_animation_effect;
+  iface->handle_list_effects = animations_dbus_server_surface_list_animation_effects;
+}
+
+static void
+animations_dbus_server_surface_set_property (GObject      *object,
+                                             guint         prop_id,
+                                             const GValue *value,
+                                             GParamSpec   *pspec)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (object);
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      priv->connection = g_value_dup_object (value);
+      break;
+    case PROP_SERVER:
+      /* Observing reference, AnimationsDbusServer is expected to last
+       * longer than AnimationsDbusServerSurface */
+      priv->server = g_value_get_object (value);
+      break;
+    case PROP_BRIDGE:
+      priv->bridge = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static GVariant *
+serialize_attached_effects_to_variant (GHashTable *effects_for_events)
+{
+  g_auto(GVariantDict) vardict;
+  gpointer key, value;
+  GHashTableIter iter;
+
+  g_variant_dict_init (&vardict, NULL);
+
+  g_hash_table_iter_init (&iter, effects_for_events);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      const char *event = key;
+      GQueue *effects = value;
+      g_auto(GVariantBuilder) builder;
+      g_autoptr(GPtrArray) names = g_ptr_array_new_full (g_queue_get_length (effects), NULL);
+
+      g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+
+      for (GList *link = g_queue_peek_head_link (effects);
+           link != NULL;
+           link = link->next)
+        {
+          AttachedEffectInfo *info = link->data;
+          g_variant_builder_add (&builder,
+                                 "s",
+                                 g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (info->server_effect)));
+        }
+
+      g_variant_dict_insert_value (&vardict,
+                                   event,
+                                   g_variant_builder_end (&builder));
+    }
+
+  return g_variant_dict_end (&vardict);
+}
+
+static void
+animations_dbus_server_surface_get_property (GObject    *object,
+                                             guint       prop_id,
+                                             GValue     *value,
+                                             GParamSpec *pspec)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (object);
+  AnimationsDbusServerSurfacePrivate *priv =
+    animations_dbus_server_surface_get_instance_private (server_surface);
+
+  switch (prop_id)
+    {
+    case PROP_CONNECTION:
+      g_value_set_object (value, priv->connection);
+      break;
+    case PROP_SERVER:
+      g_value_set_object (value, priv->server);
+      break;
+    case PROP_BRIDGE:
+      g_value_set_object (value, priv->bridge);
+      break;
+    case PROP_TITLE:
+      g_value_set_string (value,
+                          animations_dbus_server_surface_bridge_get_title (priv->bridge));
+      break;
+    case PROP_GEOMETRY:
+      g_value_set_variant (value,
+                           animations_dbus_server_surface_bridge_get_geometry (priv->bridge));
+      break;
+    case PROP_EFFECTS:
+      g_value_set_variant (value,
+                           serialize_attached_effects_to_variant (priv->attached_effects_for_events));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+animations_dbus_server_surface_dispose (GObject *object)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (object);
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  priv->server = NULL;
+  g_clear_object (&priv->bridge);
+
+  G_OBJECT_CLASS (animations_dbus_server_surface_parent_class)->dispose (object);
+}
+
+static void
+animations_dbus_server_surface_finalize (GObject *object)
+{
+  AnimationsDbusServerSurface *server_surface = ANIMATIONS_DBUS_SERVER_SURFACE (object);
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  g_clear_pointer (&priv->attached_effects_for_events, g_hash_table_unref);
+
+  G_OBJECT_CLASS (animations_dbus_server_surface_parent_class)->finalize (object);
+}
+
+static void
+attached_effect_info_queue_free (GQueue *queue)
+{
+  g_queue_free_full (queue, (GDestroyNotify) attached_effect_info_free);
+}
+
+static void
+animations_dbus_server_surface_init (AnimationsDbusServerSurface *server_surface)
+{
+  AnimationsDbusServerSurfacePrivate *priv = animations_dbus_server_surface_get_instance_private (server_surface);
+
+  priv->attached_effects_for_events = g_hash_table_new_full (g_str_hash,
+                                                             g_str_equal,
+                                                             g_free,
+                                                             (GDestroyNotify) attached_effect_info_queue_free);
+}
+
+static void
+animations_dbus_server_surface_class_init (AnimationsDbusServerSurfaceClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = animations_dbus_server_surface_get_property;
+  object_class->set_property = animations_dbus_server_surface_set_property;
+  object_class->dispose = animations_dbus_server_surface_dispose;
+  object_class->finalize = animations_dbus_server_surface_finalize;
+
+  animations_dbus_server_surface_props[PROP_CONNECTION] =
+    g_param_spec_object ("connection",
+                         "A GDBusConnection",
+                         "The GDBusConnection this surface is exported on",
+                         G_TYPE_DBUS_CONNECTION,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+  animations_dbus_server_surface_props[PROP_SERVER] =
+    g_param_spec_object ("server",
+                         "An AnimationsDbusServer",
+                         "The AnimationsDbusServer for this surface",
+                         ANIMATIONS_DBUS_TYPE_SERVER,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+  animations_dbus_server_surface_props[PROP_BRIDGE] =
+    g_param_spec_object ("bridge",
+                         "An AnimationsDbusServerSurfaceBridge",
+                         "An AnimationsDbusServerSurfaceBridge used to communicate with the underlying surface",
+                         ANIMATIONS_DBUS_TYPE_SERVER_SURFACE_BRIDGE,
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class,
+                                     N_OWN_PROPS,
+                                     animations_dbus_server_surface_props);
+
+  g_object_class_override_property (object_class,
+                                    PROP_TITLE,
+                                    "title");
+  g_object_class_override_property (object_class,
+                                    PROP_GEOMETRY,
+                                    "geometry");
+  g_object_class_override_property (object_class,
+                                    PROP_EFFECTS,
+                                    "effects");
+}
+
+AnimationsDbusServerSurface *
+animations_dbus_server_surface_new (GDBusConnection                   *connection,
+                                    AnimationsDbusServer              *server,
+                                    AnimationsDbusServerSurfaceBridge *bridge)
+{
+  return g_object_new (ANIMATIONS_DBUS_TYPE_SERVER_SURFACE,
+                       "connection", connection,
+                       "server", server,
+                       "bridge", bridge,
+                       NULL);
+}

--- a/animations-dbus/animations-dbus-server-surface.h
+++ b/animations-dbus/animations-dbus-server-surface.h
@@ -1,0 +1,58 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include <animations-dbus-objects.h>
+#include <animations-dbus-server-surface-bridge-interface.h>
+#include <animations-dbus-server-types.h>
+
+G_BEGIN_DECLS
+
+#define ANIMATIONS_DBUS_TYPE_SERVER_SURFACE animations_dbus_server_surface_get_type ()
+
+
+gboolean animations_dbus_server_surface_export (AnimationsDbusServerSurface  *server_surface,
+                                                const char                   *object_path,
+                                                GError                      **error);
+
+void animations_dbus_server_surface_unexport (AnimationsDbusServerSurface *server_surface);
+
+gboolean animations_dbus_server_surface_attach_animation_effect_with_server_priority (AnimationsDbusServerSurface  *server_surface,
+                                                                                      const char                   *event,
+                                                                                      AnimationsDbusServerEffect   *server_animation_effect,
+                                                                                      GError                      **error);
+
+AnimationsDbusServerSurfaceAttachedEffect * animations_dbus_server_surface_highest_priority_attached_effect_for_event (AnimationsDbusServerSurface *server_surface,
+                                                                                                                       const char                  *event);
+
+void animations_dbus_server_surface_emit_geometry_changed (AnimationsDbusServerSurface *server_surface);
+
+void animations_dbus_server_surface_emit_title_changed (AnimationsDbusServerSurface *server_surface);
+
+AnimationsDbusServerSurface * animations_dbus_server_surface_new (GDBusConnection                   *connection,
+                                                                  AnimationsDbusServer              *server,
+                                                                  AnimationsDbusServerSurfaceBridge *bridge);
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server-types.h
+++ b/animations-dbus/animations-dbus-server-types.h
@@ -1,0 +1,45 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+#include <glib-object.h>
+
+#include <animations-dbus-objects.h>
+
+G_DECLARE_FINAL_TYPE (AnimationsDbusServer, animations_dbus_server, ANIMATIONS_DBUS, SERVER, GObject)
+
+G_DECLARE_INTERFACE (AnimationsDbusServerEffectFactory, animations_dbus_server_effect_factory, ANIMATIONS_DBUS, SERVER_EFFECT_FACTORY, GObject)
+
+G_DECLARE_FINAL_TYPE (AnimationsDbusServerAnimationManager, animations_dbus_server_animation_manager, ANIMATIONS_DBUS, SERVER_ANIMATION_MANAGER, AnimationsDbusAnimationManagerSkeleton)
+
+G_DECLARE_FINAL_TYPE (AnimationsDbusServerSurface, animations_dbus_server_surface, ANIMATIONS_DBUS, SERVER_SURFACE, AnimationsDbusAnimatableSurfaceSkeleton)
+
+G_DECLARE_INTERFACE (AnimationsDbusServerSurfaceBridge, animations_dbus_server_surface_bridge, ANIMATIONS_DBUS, SERVER_SURFACE_BRIDGE, GObject)
+
+G_DECLARE_FINAL_TYPE (AnimationsDbusServerEffect, animations_dbus_server_effect, ANIMATIONS_DBUS, SERVER_EFFECT, AnimationsDbusAnimationEffectSkeleton)
+
+G_DECLARE_INTERFACE (AnimationsDbusServerEffectBridge, animations_dbus_server_effect_bridge, ANIMATIONS_DBUS, SERVER_EFFECT_BRIDGE, GObject)
+
+G_DECLARE_INTERFACE (AnimationsDbusServerSurfaceAttachedEffect, animations_dbus_server_surface_attached_effect, ANIMATIONS_DBUS, SERVER_SURFACE_ATTACHED_EFFECT, GObject)
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-server.h
+++ b/animations-dbus/animations-dbus-server.h
@@ -1,0 +1,46 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_SERVER_H
+
+/* Needs to be included first to break include cycles */
+#include <animations-dbus-server-types.h>
+
+#include <animations-dbus-errors.h>
+#include <animations-dbus-server-animation-manager.h>
+#include <animations-dbus-server-effect.h>
+#include <animations-dbus-server-effect-bridge-interface.h>
+#include <animations-dbus-server-effect-factory-interface.h>
+#include <animations-dbus-server-object.h>
+#include <animations-dbus-server-surface.h>
+#include <animations-dbus-server-surface-attached-effect-interface.h>
+#include <animations-dbus-server-surface-bridge-interface.h>
+#include <animations-dbus-objects.h>
+#include <animations-dbus-version.h>
+
+#undef _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_SERVER_H
+
+G_END_DECLS

--- a/animations-dbus/animations-dbus-version.h.in
+++ b/animations-dbus/animations-dbus-version.h.in
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#if !(defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_SERVER_H) || defined(COMPILING_ANIMATIONS_DBUS))
+#if !(defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_CLIENT_H) || defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_SERVER_H) || defined(COMPILING_ANIMATIONS_DBUS))
 #error "Please do not include this header file directly."
 #endif
 

--- a/animations-dbus/animations-dbus-version.h.in
+++ b/animations-dbus/animations-dbus-version.h.in
@@ -1,0 +1,98 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#if !(defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H) || defined(COMPILING_ANIMATIONS_DBUS))
+#error "Please do not include this header file directly."
+#endif
+
+/**
+ * SECTION:version-information
+ * @title: Version Information
+ * @short_description: Variables and functions to check the library version
+ *
+ * Some macros to check the version of the content library.
+ */
+
+/**
+ * ANIMATIONS_DBUS_MAJOR_VERSION:
+ *
+ * Major version number (API level) of the ANIMATIONS_DBUS library.
+ * For example, this is 0 for version 0.6.1.
+ */
+#define ANIMATIONS_DBUS_MAJOR_VERSION (@ANIMATIONS_DBUS_MAJOR_VERSION@)
+/**
+ * ANIMATIONS_DBUS_MINOR_VERSION:
+ *
+ * Minor version number of the ANIMATIONS_DBUS library.
+ * For example, this is 6 for version 0.6.1.
+ */
+#define ANIMATIONS_DBUS_MINOR_VERSION (@ANIMATIONS_DBUS_MINOR_VERSION@)
+/**
+ * ANIMATIONS_DBUS_MICRO_VERSION:
+ *
+ * Micro version number of the ANIMATIONS_DBUS library.
+ * For example, this is 1 for version 0.6.1.
+ */
+#define ANIMATIONS_DBUS_MICRO_VERSION (@ANIMATIONS_DBUS_MICRO_VERSION@)
+
+/**
+ * ANIMATIONS_DBUS_VERSION_S:
+ *
+ * Evaluates to a string with the version of ANIMATIONS_DBUS, useful for concatenating
+ * or for printing.
+ */
+#define ANIMATIONS_DBUS_VERSION_S "@ANIMATIONS_DBUS_MAJOR_VERSION@.@ANIMATIONS_DBUS_MINOR_VERSION@.@ANIMATIONS_DBUS_MICRO_VERSION@"
+
+#define _ANIMATIONS_DBUS_ENCODE_VERSION(major,minor,micro) \
+    ((major) << 24 | (minor) << 16 | (micro) << 8)
+
+/**
+ * ANIMATIONS_DBUS_VERSION:
+ *
+ * Evaluates to an encoded integer representation of the ANIMATIONS_DBUS version, useful
+ * for compile-time version comparisons.
+ *
+ * Use %ANIMATIONS_DBUS_ENCODE_VERSION to generate an integer representation that can be
+ * compared to the result of this macro, e.g.:
+ *
+ * |[<!-- language="C" -->
+ * #if ANIMATIONS_DBUS_VERSION >= ANIMATIONS_DBUS_ENCODE_VERSION (0, 6, 1)
+ *   // code that can be used with ANIMATIONS_DBUS 0.6.1 or later
+ * #elif
+ *   // code that can be used with earlier versions of ANIMATIONS_DBUS
+ * #endif
+ * ]|
+ */
+#define ANIMATIONS_DBUS_VERSION \
+  (_ANIMATIONS_DBUS_ENCODE_VERSION (ANIMATIONS_DBUS_MAJOR_VERSION, ANIMATIONS_DBUS_MINOR_VERSION, ANIMATIONS_DBUS_MICRO_VERSION))
+
+/**
+ * ANIMATIONS_DBUS_ENCODE_VERSION:
+ * @major: the major version number, e.g. 0
+ * @minor: the minor version number, e.g. 6
+ * @micro: the micro version number, e.g. 1
+ *
+ * Generates an integer-encoded representation of a ANIMATIONS_DBUS version, useful for
+ * compile-time comparisons with %ANIMATIONS_DBUS_VERSION.
+ */
+#define ANIMATIONS_DBUS_ENCODE_VERSION(major,minor,micro) \
+  (_ANIMATIONS_DBUS_ENCODE_VERSION ((major), (minor), (micro))

--- a/animations-dbus/animations-dbus-version.h.in
+++ b/animations-dbus/animations-dbus-version.h.in
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#if !(defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H) || defined(COMPILING_ANIMATIONS_DBUS))
+#if !(defined(_ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_SERVER_H) || defined(COMPILING_ANIMATIONS_DBUS))
 #error "Please do not include this header file directly."
 #endif
 

--- a/animations-dbus/animations-dbus.h
+++ b/animations-dbus/animations-dbus.h
@@ -1,0 +1,33 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * libanimation-dbus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * libanimation-dbus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-discovery-feed.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ * - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H
+
+#include <animations-dbus-version.h>
+
+#undef _ANIMATIONS_DBUS_INSIDE_ANIMATIONS_DBUS_H
+
+G_END_DECLS

--- a/animations-dbus/meson.build
+++ b/animations-dbus/meson.build
@@ -15,13 +15,34 @@ gdbus_targets = gnome.gdbus_codegen('animations-dbus-objects',
     install_dir: join_paths(get_option('includedir'), api_name, 'animations-dbus'))
 
 installed_headers = [
-    'animations-dbus.h',
+    'animations-dbus-errors.h',
+    'animations-dbus-server.h',
+    'animations-dbus-server-animation-manager.h',
+    'animations-dbus-server-effect.h',
+    'animations-dbus-server-effect-bridge-interface.h',
+    'animations-dbus-server-effect-factory-interface.h',
+    'animations-dbus-server-object.h',
+    'animations-dbus-server-surface.h',
+    'animations-dbus-server-surface-attached-effect-interface.h',
+    'animations-dbus-server-surface-bridge-interface.h',
+    'animations-dbus-server-types.h',
     version_h
 ]
 private_headers = [
+    'animations-dbus-server-skeleton-properties.h'
 ]
 sources = [
-    gdbus_targets[0]
+    gdbus_targets[0],
+    'animations-dbus-errors.c',
+    'animations-dbus-server-animation-manager.c',
+    'animations-dbus-server-effect.c',
+    'animations-dbus-server-effect-bridge-interface.c',
+    'animations-dbus-server-effect-factory-interface.c',
+    'animations-dbus-server-object.c',
+    'animations-dbus-server-skeleton-properties.c',
+    'animations-dbus-server-surface.c',
+    'animations-dbus-server-surface-attached-effect-interface.c',
+    'animations-dbus-server-surface-bridge-interface.c'
 ]
 
 include = include_directories('.')

--- a/animations-dbus/meson.build
+++ b/animations-dbus/meson.build
@@ -1,0 +1,49 @@
+# Copyright (c) 2018 Endless Mobile, Inc.
+
+version = configuration_data()
+version.set('ANIMATIONS_DBUS_MAJOR_VERSION', version_components[0])
+version.set('ANIMATIONS_DBUS_MINOR_VERSION', version_components[1])
+version.set('ANIMATIONS_DBUS_MICRO_VERSION', version_components[2])
+version_h = configure_file(configuration: version,
+    input: 'animations-dbus-version.h.in', output: 'animations-dbus-version.h')
+
+gdbus_targets = gnome.gdbus_codegen('animations-dbus-objects',
+    '../data/com.endlessm.Libanimation.xml',
+    interface_prefix: 'com.endlessm.Libanimation',
+    namespace: 'AnimationsDbus',
+    install_header: true,
+    install_dir: join_paths(get_option('includedir'), api_name, 'animations-dbus'))
+
+installed_headers = [
+    'animations-dbus.h',
+    version_h
+]
+private_headers = [
+]
+sources = [
+    gdbus_targets[0]
+]
+
+include = include_directories('.')
+
+main_library = shared_library('@0@-@1@'.format(meson.project_name(), api_version),
+    sources, installed_headers, private_headers,
+    c_args: ['-DG_LOG_DOMAIN="@0@"'.format(namespace_name),
+        '-DCOMPILING_DMODEL'],
+    dependencies: [gio, gio_unix, glib, gobject],
+    include_directories: include, install: true,
+    soversion: api_version, version: libtool_version)
+
+introspection_sources = [
+    sources,
+    join_paths(meson.build_root(), 'animations-dbus', 'animations-dbus-objects.h'),
+    installed_headers
+]
+
+gnome.generate_gir(main_library, extra_args: ['--warn-all', '--warn-error'],
+    identifier_prefix: 'AnimationsDbus', include_directories: include,
+    includes: ['Gio-2.0', 'GLib-2.0', 'GObject-2.0'],
+    install: true, namespace: namespace_name, nsversion: api_version,
+    sources: introspection_sources, symbol_prefix: 'animations_dbus')
+
+install_headers(installed_headers, subdir: api_name)

--- a/animations-dbus/meson.build
+++ b/animations-dbus/meson.build
@@ -15,6 +15,9 @@ gdbus_targets = gnome.gdbus_codegen('animations-dbus-objects',
     install_dir: join_paths(get_option('includedir'), api_name, 'animations-dbus'))
 
 installed_headers = [
+    'animations-dbus-client-effect.h',
+    'animations-dbus-client-object.h',
+    'animations-dbus-client-surface.h',
     'animations-dbus-errors.h',
     'animations-dbus-server.h',
     'animations-dbus-server-animation-manager.h',
@@ -29,10 +32,15 @@ installed_headers = [
     version_h
 ]
 private_headers = [
+    'animations-dbus-main-context-private.h',
     'animations-dbus-server-skeleton-properties.h'
 ]
 sources = [
     gdbus_targets[0],
+    'animations-dbus-client-effect.c',
+    'animations-dbus-client-object.c',
+    'animations-dbus-client-surface.c',
+    'animations-dbus-main-context-private.c',
     'animations-dbus-errors.c',
     'animations-dbus-server-animation-manager.c',
     'animations-dbus-server-effect.c',

--- a/data/com.endlessm.Libanimation.xml
+++ b/data/com.endlessm.Libanimation.xml
@@ -1,0 +1,155 @@
+<node>
+  <interface name="com.endlessm.Libanimation.ConnectionManager">
+    <!--
+      RegisterClient() -> o: Create a new AnimationManager object for
+                             the bus name of the caller’s connection.
+                             The bus name owned by the calling client
+                             will be observed by the service. The returned
+                             object path is to an AnimationManager for use
+                             by that client. When the client bus name disappears
+                             from the bus, the corresponding AnimationManager
+                             will be destroyed, along with any resources
+                             (such as AnimationEffect objects that it created).
+    -->
+    <method name="RegisterClient">
+      <arg name="path" direction="out" type="o"/>
+    </method>
+  </interface>
+  <interface name="com.endlessm.Libanimation.AnimationManager">
+    <!--
+      CreateAnimationEffect(ssa{sv}) -> o: Create a new AnimationEffect
+                                           on the bus with the title given by
+                                           the first parameter, an animation name
+                                           given by the second parameter and an
+                                           initial settings dictionary given by
+                                           the third parameter.
+
+                                           Returns the object path to the newly created
+                                           AnimationEffect on success.
+
+                                           If the animation name given by the second
+                                           parameter does not refer to a known animation,
+                                           the com.endlessm.Libanimation.NoSuchAnimation
+                                           error is raised.
+
+                                           Validation of the settings dictionary is done
+                                           by the created AnimationEffect. If validation fails, the
+                                           com.endlessm.Libanimation.UnsupportedSettingValueForAnimationEffect
+                                           error is raised. If there is no such setting name, the
+                                           com.endlessm.Libanimation.UnsupportedSettingNameForAnimationEffect
+                                           error is raised.
+
+                                           An example invocation would be
+                                           CreateAnimationEffect(“Wobbly Windows are Cool”,
+                                                                  “wobbly”,
+                                                                  {
+                                                                      “spring_constant”: {8.0},
+                                                                      “friction”: {1.0}
+                                                                  })
+    -->
+    <method name="CreateAnimationEffect">
+      <arg name="title" direction="in" type="s"/>
+      <arg name="animation" direction="in" type="s"/>
+      <arg name="settings" direction="in" type="a{sv}"/>
+      <arg name="path" direction="out" type="o"/>
+    </method>
+    <!--
+        ListSurfaces() -> (ao): Return an array listing all object paths to
+                                AnimatableSurface objects. The AnimatableSurface
+                                objects are shared between different users of the bus:
+    -->
+    <method name="ListSurfaces">
+      <arg name="surfaces" direction="out" type="ao"/>
+    </method>
+  </interface>
+  <interface name="com.endlessm.Libanimation.AnimatableSurface">
+    <!--
+        AttachAnimationEffect(so): Attach the AnimationEffect object given at the second
+                                   parameter to the event given by the first parameter on
+                                   this AnimatableSurface.
+
+                                   For instance, calling:
+
+                                       AttachAnimationEffect(“move”,
+                                                             “/com/endlessm/Libanimation/AnimationEffect/3”)
+
+                                   would attach the AnimationEffect 3 to the “move” event,
+                                   causing the AnimationEffect to be used when the surface
+                                   is moved. If the given AnimationEffect doesn’t support
+                                   the specified event type, an error
+                                   com.endlessm.Libanimation.UnsupportedEventForAnimationEffect
+                                   is raised. If the given AnimationSurface doesn’t support the
+                                   specified event type, the error
+                                   com.endlessm.Libanimation.UnsupportedEventForAnimationSurface
+                                   is raised.
+    -->
+    <method name="AttachAnimationEffect">
+      <arg name="event" direction="in" type="s"/>
+      <arg name="path" direction="in" type="o"/>
+    </method>
+    <!--
+        DetachAnimationEffect(so): Detach any AnimationEffect objects from the
+                                   event given by the first parameter. If no
+                                   AnimationEffect is attached to that event name,
+                                   the method call still succeeds but does nothing.
+                                   If the given AnimationEffect object doesn't exist,
+                                   the error com.endlessm.Libanimation.NoSuchEffect is raised.
+                                   If the given AnimationSurface doesn’t support the
+                                   specified event type, error
+                                   com.endlessm.Libanimation.UnsupportedEventForAnimationSurface
+                                   is raised.
+    -->
+    <method name="DetachAnimationEffect">
+      <arg name="event" direction="in" type="s"/>
+      <arg name="path" direction="in" type="o"/>
+    </method>
+    <!--
+        ListEffects() -> (a{sv}): Return a dictionary listing all available effect names
+                                  for a given event type on a window. For instance, the
+                                  dictionary may have the form:
+
+                                  {
+                                      “move”: [“wobbly”],
+                                      “open”: [“zoom”],
+                                      “close” [“zoom”]
+                                  }
+
+    -->
+    <method name="ListEffects">
+      <arg name="effects" direction="out" type="a{sv}"/>
+    </method>
+    <property name="Title" type="s" access="read"/>
+    <property name="Geometry" type="(iiii)" access="read"/>
+    <property name="Effects" type="a{sv}" access="read"/>
+  </interface>
+  <interface name="com.endlessm.Libanimation.AnimationEffect">
+    <!--
+        ChangeSetting(sv): Change the setting at the name given by the first parameter
+                           to have the value specified by the variant in the second parameter.
+
+                           Validation is done by the animation implementation.
+                           If validation fails, the
+                           com.endlessm.Libanimation.UnsupportedSettingValueForAnimationEffect
+                           error is raised. If there is no such setting name, the
+                           com.endlessm.Libanimation.UnsupportedSettingNameForAnimationEffect
+                           error is raised.
+
+                           An example invocation would be:
+                           ChangeSetting(“spring_constant”, {8.0}).
+    -->
+    <method name="ChangeSetting">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="value" direction="in" type="v"/>
+    </method>
+    <!--
+        Delete(): Delete the given AnimationEffect object on the bus.
+                  The AnimationEffect will be implicitly detached from all
+                  AnimatableSurface objects.
+    -->
+    <method name="Delete">
+    </method>
+    <property name="Title" type="s" access="read"/>
+    <property name="Settings" type="a{sv}" access="read"/>
+    <property name="Schema" type="a{sv}" access="read"/>
+  </interface>
+<node>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,3 @@
+# Copyright 2018 Endless Mobile, Inc.
+
+

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,0 +1,54 @@
+// /examples/client.js
+//
+// Copyright (c) 2018 Endless Mobile Inc.
+//
+// Example client for AnimationsDbus
+
+const AnimationsDbus = imports.gi.AnimationsDbus;
+const GLib = imports.gi.GLib;
+
+const Mainloop = imports.mainloop;
+
+function boot() {
+  AnimationsDbus.Client.new_async(null, (source, result) => {
+    let client = AnimationsDbus.Client.new_finish(source, result);
+
+    log('Got client, listing surfaces');
+    client.list_surfaces_async(null, (source, result) => {
+      let surfaces = source.list_surfaces_finish(result);
+
+      if (surfaces.length > 0) {
+        surfaces[0].list_available_effects_async(null, (source, result) => {
+          let effects = source.list_available_effects_finish(result);
+          let event = Object.keys(effects)[0];
+          let selectedEffectName = effects[event][0];
+
+          log(`Available effects on "${surfaces[0].title}" are: ${JSON.stringify(effects, null, 2)}`);
+          log(`Creating effect ${selectedEffectName} on the bus`);
+
+          client.create_animation_effect_async(`My special ${selectedEffectName} effect`,
+                                               selectedEffectName,
+                                               new GLib.Variant('a{sv}', {}),
+                                               null,
+                                               (source, result) => {
+            let effect = source.create_animation_effect_finish(result);
+            log(`Created effect with object path: ${effect.get_object_path()}`);
+            log(`Effect settings are: ${JSON.stringify(effect.settings.deep_unpack())}`);
+            log(`Effect schema is: ${JSON.stringify(effect.schema.deep_unpack())}`);
+
+            log(`Attaching effect to surface: "${surfaces[0].title}"`);
+            surfaces[0].attach_effect_async(event, effect, null, (source, result) => {
+              surfaces[0].attach_effect_finish(result);
+              log(`Attached effect ${selectedEffectName} "${surfaces[0].title}"`);
+            });
+          });
+        });
+      }
+    });
+  });
+}
+
+GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, boot);
+Mainloop.run();
+
+

--- a/examples/client_sync.js
+++ b/examples/client_sync.js
@@ -1,0 +1,39 @@
+// /examples/client.js
+//
+// Copyright (c) 2018 Endless Mobile Inc.
+//
+// Example client for AnimationsDbus
+
+const AnimationsDbus = imports.gi.AnimationsDbus;
+const GLib = imports.gi.GLib;
+
+const Console = imports.console;
+
+let client = AnimationsDbus.Client.new();
+
+log('Got client, listing surfaces');
+let surfaces = client.list_surfaces();
+
+if (surfaces.length > 0) {
+  let effects = surfaces[0].list_available_effects();
+  let event = Object.keys(effects)[0];
+  let selectedEffectName = effects[event][0];
+
+  log(`Available effects on "${surfaces[0].title}" are: ${JSON.stringify(effects, null, 2)}`);
+  log(`Creating effect ${selectedEffectName} on the bus`);
+
+  let effect = client.create_animation_effect(`My special ${selectedEffectName} effect`,
+                                              selectedEffectName,
+                                              new GLib.Variant('a{sv}', {}));
+
+  log(`Created effect with object path: ${effect.get_object_path()}`);
+  log(`Effect settings are: ${JSON.stringify(effect.settings.deep_unpack())}`);
+  log(`Effect schema is: ${JSON.stringify(effect.schema.deep_unpack())}`);
+  log(`Attaching effect to surface: "${surfaces[0].title}"`);
+
+  surfaces[0].attach_effect(event, effect);
+  log(`Attached effect ${selectedEffectName} "${surfaces[0].title}"`);
+}
+
+Console.interact();
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,35 @@
+# Copyright 2018 Endless Mobile, Inc.
+
+project('animations-dbus', 'c', version: '0.0.0', license: 'LGPL2.1+',
+    meson_version: '>= 0.42.0',
+    default_options: ['c_std=c99', 'warning_level=3'])
+
+gnome = import('gnome')
+pkg = import('pkgconfig')
+
+version_components = meson.project_version().split('.')
+api_version = version_components[0]
+api_name = '@0@-@1@'.format(meson.project_name(), api_version)
+libtool_version = '0.0.0'
+namespace_name = 'AnimationsDbus'
+
+gio = dependency('gio-2.0')
+gio_unix = dependency('gio-unix-2.0')
+glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
+
+config = configuration_data()
+config.set_quoted('ANIMATIONS_DBUS_VERSION', meson.project_version())
+configure_file(configuration: config, output: 'config.h')
+
+subdir('data')
+subdir('animations-dbus')
+
+requires = [gio, gio_unix, glib, gobject]
+
+pkg.generate(filebase: api_name, libraries: [main_library],
+    description: 'DBus API for remotely programmable animations',
+    name: meson.project_name(), subdirs: api_name, requires: requires,
+    url: 'http://endlessm.github.io/libanimation-dbus',
+    version: meson.project_version())
+

--- a/meson.build
+++ b/meson.build
@@ -22,8 +22,15 @@ config = configuration_data()
 config.set_quoted('ANIMATIONS_DBUS_VERSION', meson.project_version())
 configure_file(configuration: config, output: 'config.h')
 
+jasmine_report_argument = ''
+junit_reports_dir = get_option('jasmine_junit_reports_dir')
+if junit_reports_dir != ''
+    jasmine_report_argument = '--junit=@0@/${log/.log/.js.xml}'.format(junit_reports_dir)
+endif
+
 subdir('data')
 subdir('animations-dbus')
+subdir('tests')
 
 requires = [gio, gio_unix, glib, gobject]
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('jasmine_junit_reports_dir', type: 'string',
+    description: 'Where to put test reports')

--- a/tests/libanimations-dbus/testClient.js
+++ b/tests/libanimations-dbus/testClient.js
@@ -1,0 +1,620 @@
+const {
+    AnimationsDbus,
+    Gio,
+    GLib,
+    GObject
+} = imports.gi;
+
+const Lang = imports.lang;
+const System = imports.system;
+
+const FakeServerSurfaceBridge = new Lang.Class({
+    Name: 'FakeServerSurfaceBridge',
+    Extends: GObject.Object,
+    Implements: [ AnimationsDbus.ServerSurfaceBridge ],
+    Properties: {
+        title: GObject.ParamSpec.string('title',
+                                        'Title',
+                                        'Surface Title',
+                                        GObject.ParamFlags.READWRITE |
+                                        GObject.ParamFlags.CONSTRUCT,
+                                        'Default Title'),
+        geometry: GObject.param_spec_variant('geometry',
+                                             'Geometry',
+                                             'Surface Geometry',
+                                             new GLib.VariantType('(iiii)'),
+                                             new GLib.Variant('(iiii)', [0, 0, 1, 1]),
+                                             GObject.ParamFlags.READWRITE |
+                                             GObject.ParamFlags.CONSTRUCT)
+    },
+
+    _init: function(props) {
+        this.parent(props);
+
+        this._effects = {};
+    },
+
+    vfunc_attach_effect: function(event, effect) {
+        if (event !== 'move')
+            throw new GLib.Error(AnimationsDbus.error_quark(),
+                                 AnimationsDbus.Error.UNSUPPORTED_EVENT_FOR_ANIMATION_EFFECT,
+                                 `Unsupported event ${event}`);
+
+        return new FakeAttachedAnimationEffect({ bridge: effect.bridge });
+    },
+
+    vfunc_detach_effect: function(event, effect) {
+    },
+
+    vfunc_get_title: function() {
+        return this.title;
+    },
+
+    vfunc_get_geometry: function() {
+        return this.geometry;
+    },
+
+    vfunc_get_available_effects: function() {
+        return {
+            'move': ['fake-effect']
+        };
+    }
+});
+
+const FakeAnimationEffectBridge = new Lang.Class({
+    Name: 'FakeAnimationEffectBridge',
+    Extends: GObject.Object,
+    Implements: [ AnimationsDbus.ServerEffectBridge ],
+    Properties: {
+        some_property: GObject.ParamSpec.int('some-property',
+                                             'Some Property',
+                                             'Some long property description',
+                                             GObject.ParamFlags.READWRITE |
+                                             GObject.ParamFlags.CONSTRUCT,
+                                             0,
+                                             10,
+                                             5)
+    },
+
+    vfunc_get_name: function() {
+        return 'fake-effect';
+    }
+});
+
+const FakeAttachedAnimationEffect = new Lang.Class({
+    Name: 'FakeAttachedAnimationEffect',
+    Extends: GObject.Object,
+    Implements: [ AnimationsDbus.ServerSurfaceAttachedEffect ],
+    Properties: {
+        bridge: GObject.ParamSpec.object('bridge',
+                                         'FakeAnimationEffectBridge',
+                                         'The FakeAnimationEffectBridge that is the metaclass',
+                                         GObject.ParamFlags.READWRITE |
+                                         GObject.ParamFlags.CONSTRUCT_ONLY,
+                                         FakeAnimationEffectBridge)
+    }
+});
+
+const FakeAnimationEffectBridgeProvider = new Lang.Class({
+    Name: 'FakeAnimationEffectBridgeProvider',
+    Extends: GObject.Object,
+    Implements: [ AnimationsDbus.ServerEffectFactory ],
+
+    vfunc_create_effect: function(name, settings) {
+        switch (name) {
+        case 'fake-effect':
+            return new FakeAnimationEffectBridge({});
+            break;
+        default:
+            throw new GLib.Error(AnimationsDbus.error_quark(),
+                                 AnimationsDbus.Error.NO_SUCH_ANIMATION,
+                                 `Cannot create animaton with name ${name}`);
+        }   
+    }
+});
+
+function reportGError(error) {
+    expect(`Error ${error.domain}: ${error.code} "${error.message}" occurred`).toEqual('');
+}
+
+function doneHandlerExceptionOnly(done, func) {
+    return (...args) => {
+        try {
+            func(...args);
+        } catch (e) {
+            reportGError(e);
+            done();
+        }
+    }
+}
+
+function doneHandler(done, func) {
+    return (...args) => {
+        try {
+            func(...args);
+            done();
+        } catch (e) {
+            reportGError(e);
+            done();
+        }
+    }
+}
+
+// Taken from libdmodel
+const customMatchers = {
+    toBeA: function (util, customEqualityTesters) {
+        return {
+            compare: function (object, expectedType) {
+                let result = {
+                    pass: function () {
+                        return object instanceof expectedType;
+                    }()
+                }
+
+                let objectTypeName;
+                if (typeof object === 'object')
+                    objectTypeName = object.constructor.name;
+                else
+                    objectTypeName = typeof widget;
+
+                let expectedTypeName;
+                if (typeof expectedType.$gtype !== 'undefined')
+                    expectedTypeName = expectedType.$gtype.name;
+                else
+                    expectedTypeName = expectedType;
+
+                if (result.pass) {
+                    result.message = 'Expected ' + object + ' not to be a ' + expectedTypeName + ', but it was';
+                } else {
+                    result.message = 'Expected ' + object + ' to be a ' + expectedTypeName + ', but instead it had type ' + objectTypeName;
+                }
+                return result;
+            }
+        }
+    }
+};
+
+describe('Animations DBus', function() {
+    let testDBus = Gio.TestDBus.new(Gio.TestDBusFlags.NONE);
+    let serverConnection = null;
+    let clientConnection = null;
+
+    beforeAll(function() {
+        jasmine.addMatchers(customMatchers);
+    });
+
+    beforeEach(function() {
+        testDBus.up();
+
+        serverConnection =
+            Gio.DBusConnection.new_for_address_sync(testDBus.get_bus_address(),
+                                                    Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT |
+                                                    Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
+                                                    null,
+                                                    null);
+        clientConnection =
+            Gio.DBusConnection.new_for_address_sync(testDBus.get_bus_address(),
+                                                    Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT |
+                                                    Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
+                                                    null,
+                                                    null);
+    });
+
+    afterEach(function() {
+        testDBus.down();
+    });
+
+    describe('Server', function() {
+        let server = null;
+
+        beforeEach(function(done) {
+            let provider = new FakeAnimationEffectBridgeProvider({});
+            AnimationsDbus.Server.new_with_connection_async(provider,
+                                                            serverConnection,
+                                                            null,
+                                                            doneHandler(done, function(source, result) {
+                server = AnimationsDbus.Server.new_finish(source, result);
+            }));
+        });
+
+        afterEach(function() {
+            server = null;
+        });
+
+        describe('with a connected Client', function() {
+            let client = null;
+
+            beforeEach(function(done) {
+                AnimationsDbus.Client.new_with_connection_async(clientConnection,
+                                                                null,
+                                                                doneHandler(done, function(source, result) {
+                    client = AnimationsDbus.Client.new_finish(source, result);
+                }));
+            });
+
+            it('can create a known animation effect', function(done) {
+                client.create_animation_effect_async('My cool effect',
+                                                     'fake-effect',
+                                                     new GLib.Variant('a{sv}', {}),
+                                                     null,
+                                                     doneHandler(done, function(source, result) {
+                    let effect = source.create_animation_effect_finish(result);
+                    expect(effect.title).toBe('My cool effect');
+                }));
+            });
+
+            it('can create a known animation effect with custom settings', function(done) {
+                client.create_animation_effect_async('My cool effect',
+                                                     'fake-effect',
+                                                     new GLib.Variant('a{sv}', {
+                                                         'some-property': new GLib.Variant('i', 2)
+                                                     }),
+                                                     null,
+                                                     doneHandler(done, function(source, result) {
+                    let effect = source.create_animation_effect_finish(result);
+                    expect(effect.settings.deep_unpack()['some-property'].deep_unpack()).toBe(
+                        2
+                    );
+                }));
+            });
+
+            // Skipped for now, since we don't have any way of validating
+            // settings on construction.
+            xit('creating a known animation effect with invalid setting name throws', function(done) {
+                client.create_animation_effect_async('My cool effect',
+                                                     'fake-effect',
+                                                     new GLib.Variant('a{sv}', {
+                                                         'bad-property': new GLib.Variant('i', 2)
+                                                     }),
+                                                     null,
+                                                     doneHandler(done, function(source, result) {
+                    expect(function() {
+                        source.create_animation_effect_finish(result);
+                    }).toThrow();
+                }));
+            });
+
+            // Skipped for now, since we don't have any way of validating
+            // settings on construction.
+            xit('creating a known animation effect with invalid setting value throws', function(done) {
+                client.create_animation_effect_async('My cool effect',
+                                                     'fake-effect',
+                                                     new GLib.Variant('a{sv}', {
+                                                         'some-property': new GLib.Variant('i', 100)
+                                                     }),
+                                                     null,
+                                                     doneHandler(done, function(source, result) {
+                    expect(function() {
+                        source.create_animation_effect_finish(result);
+                    }).toThrow();
+                }));
+            });
+
+            // Skipped, since throwing errors across vfunc boundaries
+            // in Gjs does not appear to work correctly.
+            xit('creating an unknown animation effect throws', function(done) {
+                client.create_animation_effect_async('My cool effect',
+                                                     'unknown-effect',
+                                                     new GLib.Variant('a{sv}', {}),
+                                                     null,
+                                                     doneHandler(done, function(source, result) {
+                    expect(function() {
+                        source.create_animation_effect_finish(result);
+                    }).toThrow();
+                }));
+            });
+
+            describe('with an attached surface', function() {
+                let surface = null;
+                let serverSurface = null;
+
+                beforeEach(function() {
+                    surface = new FakeServerSurfaceBridge({});
+                    serverSurface = server.register_surface(surface);
+                });
+
+                it('shows up in the client surface listing', function(done) {
+                    client.list_surfaces_async(null, doneHandler(done, function(source, result) {
+                        let surfaces = source.list_surfaces_finish(result);
+
+                        expect(surfaces.length).toBe(1);
+                    }));
+                });
+
+                it('changed geometry is reflected in properties if changed before querying', function(done) {
+                    surface.geometry = new GLib.Variant('(iiii)', [100, 100, 200, 200]);
+                    client.list_surfaces_async(null, doneHandler(done, function(source, result) {
+                        let surfaces = source.list_surfaces_finish(result);
+
+                        expect(surfaces[0].geometry.deep_unpack()).toEqual([100, 100, 200, 200]);
+                    }));
+                });
+
+                describe('first surface in client surface listing', function() {
+                    let clientSurface = null;
+
+                    beforeEach(function(done) {
+                        client.list_surfaces_async(null, doneHandler(done, function(source, result) {
+                            let surfaces = source.list_surfaces_finish(result);
+
+                            clientSurface = surfaces[0];
+                        }));
+                    });
+
+                    it('has the expected object path', function() {
+                         expect(clientSurface.proxy.get_object_path()).toBe(
+                             '/com/endlessm/Libanimation/AnimatableSurface/0'
+                         );
+                     });
+
+                     it('has the expected title', function() {
+                         expect(clientSurface.title).toBe('Default Title');
+                     });
+
+                     it('changed title is not reflected in properties if changed after querying', function() {
+                         surface.title = 'New Title';
+                         expect(clientSurface.title).not.toEqual('newTitle');
+                     });
+
+                     it('changed title is reflected in properties after emitting the change signal', function(done) {
+                         let conn = clientSurface.proxy.connect('notify::title', doneHandler(done, function() {
+                             expect(clientSurface.title).toEqual('New Title');
+                             clientSurface.proxy.disconnect(conn);
+                         }));
+                         surface.title = 'New Title';
+                         serverSurface.emit_title_changed();
+                     });
+
+                     it('has the expected geometry', function() {
+                         expect(clientSurface.geometry.deep_unpack()).toEqual([0, 0, 1, 1]);
+                     });
+
+                     it('changed geometry is not reflected in properties if changed after querying', function() {
+                         surface.geometry = new GLib.Variant('(iiii)', [100, 100, 200, 200]);
+                         expect(clientSurface.geometry.deep_unpack()).not.toEqual([100, 100, 200, 200]);
+                     });
+
+                     it('changed geometry is reflected in properties after emitting the change signal', function(done) {
+                         let conn = clientSurface.proxy.connect('notify::geometry', doneHandler(done, function() {
+                             expect(clientSurface.geometry.deep_unpack()).toEqual([100, 100, 200, 200]);
+                             clientSurface.proxy.disconnect(conn);
+                         }));
+                         surface.geometry = new GLib.Variant('(iiii)', [100, 100, 200, 200]);
+                         serverSurface.emit_geometry_changed();
+                     });
+                });
+            });
+
+            describe('with a created animation effect', function() {
+                let effect = null;
+
+                beforeEach(function(done) {
+                    client.create_animation_effect_async('My cool effect',
+                                                         'fake-effect',
+                                                         new GLib.Variant('a{sv}', {}),
+                                                         null,
+                                                         doneHandler(done, function(source, result) {
+                        effect = source.create_animation_effect_finish(result);
+                    }));
+                });
+
+                it('has the expected object path', function() {
+                    expect(effect.proxy.get_object_path()).toBe(
+                        '/com/endlessm/Libanimation/AnimationManager/1/AnimationEffect/0'
+                    );
+                });
+
+                it('has a property in its schema called some-property', function() {
+                    expect(Object.keys(effect.schema.deep_unpack())).toContain(
+                        'some-property'
+                    );
+                });
+
+                it('the type of some-property is i', function() {
+                    expect(effect.schema.deep_unpack()['some-property'].deep_unpack().type.deep_unpack()).toBe(
+                        'i'
+                    );
+                });
+
+                it('the default of some-property is 5', function() {
+                    expect(effect.schema.deep_unpack()['some-property'].deep_unpack().default.deep_unpack()).toBe(
+                        5
+                    );
+                });
+
+                it('the min of some-property is 0', function() {
+                    expect(effect.schema.deep_unpack()['some-property'].deep_unpack().min.deep_unpack()).toBe(
+                        0
+                    );
+                });
+
+                it('the max of some-property is 10', function() {
+                    expect(effect.schema.deep_unpack()['some-property'].deep_unpack().max.deep_unpack()).toBe(
+                        10
+                    );
+                });
+
+                it('has the a key in its settings called some-property', function() {
+                    expect(Object.keys(effect.settings.deep_unpack())).toContain(
+                        'some-property'
+                    );
+                });
+
+                it('the value of some-property is 5', function() {
+                    expect(effect.settings.deep_unpack()['some-property'].deep_unpack()).toBe(
+                        5
+                    );
+                });
+
+                it('can change settings on that effect', function(done) {
+                    effect.change_setting_async('some-property',
+                                                new GLib.Variant('i', 2),
+                                                null,
+                                                doneHandler(done, function(source, result) {
+                        expect(source.change_setting_finish(result)).toBeTruthy();
+                    }));
+                });
+
+                it('changed settings on that effect get reflected in the properties', function(done) {
+                    let conn = effect.proxy.connect('notify::settings', function() {
+                        expect(effect.settings.deep_unpack()['some-property'].deep_unpack()).toBe(2);
+                        effect.proxy.disconnect(conn);
+                        done();
+                    })
+                    effect.change_setting_async('some-property',
+                                                new GLib.Variant('i', 2),
+                                                null,
+                                                doneHandler(done, function(source, result) {
+                        expect(source.change_setting_finish(result)).toBeTruthy();
+                    }));
+                });
+
+                it('changing setting to invalid value throws', function(done) {
+                    effect.change_setting_async('some-property',
+                                                new GLib.Variant('i', 100),
+                                                null,
+                                                doneHandler(done, function(source, result) {
+                        expect(function() {
+                            source.change_setting_finish(result);
+                        }).toThrow();
+                    }));
+                });
+
+                describe('with some attached surfaces', function() {
+                    let serverSurface1 = null;
+                    let serverSurface2 = null;
+                    let clientSurfaces = null;
+
+                    beforeEach(function(done) {
+                        serverSurface1 = server.register_surface(new FakeServerSurfaceBridge({
+                            title: 'Server Surface 1'
+                        }));
+                        serverSurface2 = server.register_surface(new FakeServerSurfaceBridge({
+                            title: 'Server Surface 2'
+                        }));
+                        clientSurfaces = null;
+
+                        client.list_surfaces_async(null, doneHandler(done, function(source, result) {
+                            clientSurfaces = source.list_surfaces_finish(result);
+                        }));
+                    });
+
+                    it('can be attached to the move event', function(done) {
+                        clientSurfaces[0].attach_effect_async('move', effect, null, doneHandler(done, function(source, result) {
+                            expect(source.attach_effect_finish(result)).toBe(true);
+                        }));
+                    });
+
+                    xit('throws if attached to a unsupported event', function(done) {
+                        clientSurfaces[0].attach_effect_async('unsupported', effect, null, doneHandler(done, function(source, result) {
+                            expect(function() {
+                                source.attach_effect_finish(result)
+                            }).toThrow();
+                        }));
+                    });
+
+                    it('has move event in the effects property when attached', function(done) {
+                        let conn = clientSurfaces[0].proxy.connect('notify::effects', doneHandler(done, function() {
+                            expect(Object.keys(clientSurfaces[0].effects.deep_unpack())).toContain('move');
+                            clientSurfaces[0].proxy.disconnect(conn);
+                        }));
+                        clientSurfaces[0].attach_effect_async('move', effect, null, doneHandlerExceptionOnly(done, function(source, result) {
+                            expect(source.attach_effect_finish(result)).toBe(true);
+                        }));
+                    });
+
+                    it('effect for move event when attached is of expected object path', function(done) {
+                        let conn = clientSurfaces[0].proxy.connect('notify::effects', doneHandler(done, function() {
+                            expect(clientSurfaces[0].effects.deep_unpack()['move'].deep_unpack()).toContain(
+                                effect.get_object_path()
+                            );
+                            clientSurfaces[0].proxy.disconnect(conn);
+                        }));
+                        clientSurfaces[0].attach_effect_async('move', effect, null, doneHandlerExceptionOnly(done, function(source, result) {
+                            expect(source.attach_effect_finish(result)).toBe(true);
+                        }));
+                    });
+
+                    describe('with attached effect for move event', function() {
+                        beforeEach(function(done) {
+                            clientSurfaces[0].attach_effect_async('move', effect, null, doneHandler(done, function(source, result) {
+                                source.attach_effect_finish(result);
+                            }));
+                        });
+
+                        it('is the highest priority event on the server side', function() {
+                            let attachedEffect = serverSurface1.highest_priority_attached_effect_for_event('move');
+
+                            expect(attachedEffect).toBeA(FakeAttachedAnimationEffect);
+                        });
+
+                        it('is removed when the server connection closes', function(done) {
+                            server.connect('client-disconnected', doneHandler(done, function() {
+                                let attachedEffect = serverSurface1.highest_priority_attached_effect_for_event('move');
+                                expect(attachedEffect).toBe(null);
+                            }));
+
+                            // Close the connection. This will cause the name to be lost
+                            // and state to be cleaned up on the server side.
+                            clientConnection.close(null, doneHandlerExceptionOnly(done, function(source, result) {
+                                clientConnection.close_finish(result);
+                            }));
+                        });
+
+                        describe('with an attached server-priority effect for move event', function() {
+                            let serverAnimationManager = null;
+                            let serverEffect = null;
+
+                            beforeEach(function() {
+                                serverAnimationManager = server.create_animation_manager();
+                                serverEffect = serverAnimationManager.create_effect('Server Effect',
+                                                                                    'fake-effect',
+                                                                                    new GLib.Variant('a{sv}',
+                                                                                                     { some_property: new GLib.Variant('i', 7) }));
+
+                                serverSurface1.attach_animation_effect_with_server_priority('move', serverEffect);
+                            });
+
+                            // Need to explicitly destroy the server effect to avoid
+                            // calling back into the JSAPI from dispose()
+                            afterEach(function() {
+                                if (serverEffect !== null) {
+                                    serverEffect.destroy();
+                                    serverEffect = null;
+                                }
+                            });
+
+                            it('takes priority over server attached effects', function() {
+                                let attachedEffect = serverSurface1.highest_priority_attached_effect_for_event('move');
+
+                                expect(attachedEffect.bridge.some_property).not.toBe(7);
+                            });
+
+                            it('is overtaken by server attached effects when deleted', function(done) {
+                                clientSurfaces[0].detach_effect_async('move', effect, null, doneHandler(done, function(source, result) {
+                                    source.detach_effect_finish(result);
+
+                                    let attachedEffect = serverSurface1.highest_priority_attached_effect_for_event('move');
+                                    expect(attachedEffect.bridge.some_property).toBe(7);
+                                }));
+                            });
+
+                            it('is overtaken by server attached effects when the client disconnects', function(done) {
+                                server.connect('client-disconnected', doneHandler(done, function() {
+                                    let attachedEffect = serverSurface1.highest_priority_attached_effect_for_event('move');
+                                    expect(attachedEffect.bridge.some_property).toBe(7);
+                                }));
+
+                                // Close the connection. This will cause the name to be lost
+                                // and state to be cleaned up on the server side.
+                                clientConnection.close(null, doneHandlerExceptionOnly(done, function(source, result) {
+                                    clientConnection.close_finish(result);
+                                }));
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,30 @@
+# Copyright 2018 Endless Mobile, Inc.
+
+javascript_tests = [
+    'libanimations-dbus/testClient.js',
+]
+
+jasmine = find_program('jasmine')
+test_runner = find_program('./tap.py')
+include_path = '@0@:@1@'.format(meson.source_root(), meson.build_root())
+built_library_path = join_paths(meson.build_root(), meson.project_name())
+test_content_path = join_paths(meson.current_source_dir(), 'testcontent')
+tests_environment = environment()
+tests_environment.set('GJS_PATH', include_path)
+tests_environment.prepend('GI_TYPELIB_PATH', built_library_path)
+tests_environment.prepend('LD_LIBRARY_PATH', built_library_path)
+tests_environment.set('G_TEST_SRCDIR', meson.current_source_dir())
+tests_environment.set('G_TEST_BUILDDIR', meson.current_build_dir())
+tests_environment.prepend('XDG_DATA_DIRS', test_content_path)
+tests_environment.set('LC_ALL', 'C')
+
+args = [jasmine.path(), '--no-config', '--tap']
+if (jasmine_report_argument != '')
+    args += [jasmine_report_argument]
+endif
+
+foreach test_file : javascript_tests
+    srcdir_file = join_paths(meson.current_source_dir(), test_file)
+    test(test_file, test_runner, env: tests_environment,
+        args: args + [srcdir_file])
+endforeach

--- a/tests/tap.py
+++ b/tests/tap.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+# Adapted from tappy copyright (c) 2016, Matt Layman
+# MIT license
+# https://github.com/python-tap/tappy
+
+import io
+import re
+import subprocess
+import sys
+
+
+class Directive(object):
+    """A representation of a result line directive."""
+
+    skip_pattern = re.compile(
+        r"""^SKIP\S*
+            (?P<whitespace>\s*) # Optional whitespace.
+            (?P<reason>.*)      # Slurp up the rest.""",
+        re.IGNORECASE | re.VERBOSE)
+    todo_pattern = re.compile(
+        r"""^TODO\b             # The directive name
+            (?P<whitespace>\s*) # Immediately following must be whitespace.
+            (?P<reason>.*)      # Slurp up the rest.""",
+        re.IGNORECASE | re.VERBOSE)
+
+    def __init__(self, text):
+        """Initialize the directive by parsing the text.
+        The text is assumed to be everything after a '#\s*' on a result line.
+        """
+        self._text = text
+        self._skip = False
+        self._todo = False
+        self._reason = None
+
+        match = self.skip_pattern.match(text)
+        if match:
+            self._skip = True
+            self._reason = match.group('reason')
+
+        match = self.todo_pattern.match(text)
+        if match:
+            if match.group('whitespace'):
+                self._todo = True
+            else:
+                # Catch the case where the directive has no descriptive text.
+                if match.group('reason') == '':
+                    self._todo = True
+            self._reason = match.group('reason')
+
+    @property
+    def text(self):
+        """Get the entire text."""
+        return self._text
+
+    @property
+    def skip(self):
+        """Check if the directive is a SKIP type."""
+        return self._skip
+
+    @property
+    def todo(self):
+        """Check if the directive is a TODO type."""
+        return self._todo
+
+    @property
+    def reason(self):
+        """Get the reason for the directive."""
+        return self._reason
+
+
+class Parser(object):
+    """A parser for TAP files and lines."""
+
+    # ok and not ok share most of the same characteristics.
+    result_base = r"""
+        \s*                    # Optional whitespace.
+        (?P<number>\d*)        # Optional test number.
+        \s*                    # Optional whitespace.
+        (?P<description>[^#]*) # Optional description before #.
+        \#?                    # Optional directive marker.
+        \s*                    # Optional whitespace.
+        (?P<directive>.*)      # Optional directive text.
+    """
+    ok = re.compile(r'^ok' + result_base, re.VERBOSE)
+    not_ok = re.compile(r'^not\ ok' + result_base, re.VERBOSE)
+    plan = re.compile(r"""
+        ^1..(?P<expected>\d+) # Match the plan details.
+        [^#]*                 # Consume any non-hash character to confirm only
+                              # directives appear with the plan details.
+        \#?                   # Optional directive marker.
+        \s*                   # Optional whitespace.
+        (?P<directive>.*)     # Optional directive text.
+    """, re.VERBOSE)
+    diagnostic = re.compile(r'^#')
+    bail = re.compile(r"""
+        ^Bail\ out!
+        \s*            # Optional whitespace.
+        (?P<reason>.*) # Optional reason.
+    """, re.VERBOSE)
+    version = re.compile(r'^TAP version (?P<version>\d+)$')
+
+    TAP_MINIMUM_DECLARED_VERSION = 13
+
+    def parse(self, fh):
+        """Generate tap.line.Line objects, given a file-like object `fh`.
+        `fh` may be any object that implements both the iterator and
+        context management protocol (i.e. it can be used in both a
+        "with" statement and a "for...in" statement.)
+        Trailing whitespace and newline characters will be automatically
+        stripped from the input lines.
+        """
+        with fh:
+            for line in fh:
+                yield self.parse_line(line.rstrip())
+
+    def parse_line(self, text):
+        """Parse a line into whatever TAP category it belongs."""
+        match = self.ok.match(text)
+        if match:
+            return self._parse_result(True, match)
+
+        match = self.not_ok.match(text)
+        if match:
+            return self._parse_result(False, match)
+
+        if self.diagnostic.match(text):
+            return ('diagnostic', text)
+
+        match = self.plan.match(text)
+        if match:
+            return self._parse_plan(match)
+
+        match = self.bail.match(text)
+        if match:
+            return ('bail', match.group('reason'))
+
+        match = self.version.match(text)
+        if match:
+            return self._parse_version(match)
+
+        return ('unknown',)
+
+    def _parse_plan(self, match):
+        """Parse a matching plan line."""
+        expected_tests = int(match.group('expected'))
+        directive = Directive(match.group('directive'))
+
+        # Only SKIP directives are allowed in the plan.
+        if directive.text and not directive.skip:
+            return ('unknown',)
+
+        return ('plan', expected_tests, directive)
+
+    def _parse_result(self, ok, match):
+        """Parse a matching result line into a result instance."""
+        return ('result', ok, match.group('number'),
+            match.group('description').strip(),
+            Directive(match.group('directive')))
+
+    def _parse_version(self, match):
+        version = int(match.group('version'))
+        if version < self.TAP_MINIMUM_DECLARED_VERSION:
+            raise ValueError('It is an error to explicitly specify '
+                             'any version lower than 13.')
+        return ('version', version)
+
+
+class Rules(object):
+
+    def __init__(self):
+        self._lines_seen = {'plan': [], 'test': 0, 'failed': 0, 'version': []}
+        self._errors = []
+
+    def check(self, final_line_count):
+        """Check the status of all provided data and update the suite."""
+        if self._lines_seen['version']:
+            self._process_version_lines()
+        self._process_plan_lines(final_line_count)
+
+    def check_errors(self):
+        if self._lines_seen['failed'] > 0:
+            self._add_error('Tests failed.')
+        if self._errors:
+            for error in self._errors:
+                print(error)
+            return 1
+        return 0
+
+    def _process_version_lines(self):
+        """Process version line rules."""
+        if len(self._lines_seen['version']) > 1:
+            self._add_error('Multiple version lines appeared.')
+        elif self._lines_seen['version'][0] != 1:
+            self._add_error('The version must be on the first line.')
+
+    def _process_plan_lines(self, final_line_count):
+        """Process plan line rules."""
+        if not self._lines_seen['plan']:
+            self._add_error('Missing a plan.')
+            return
+
+        if len(self._lines_seen['plan']) > 1:
+            self._add_error('Only one plan line is permitted per file.')
+            return
+
+        expected_tests, at_line = self._lines_seen['plan'][0]
+        if not self._plan_on_valid_line(at_line, final_line_count):
+            self._add_error(
+                'A plan must appear at the beginning or end of the file.')
+            return
+
+        if expected_tests != self._lines_seen['test']:
+            self._add_error(
+                'Expected {expected_count} tests '
+                'but only {seen_count} ran.'.format(
+                    expected_count=expected_tests,
+                    seen_count=self._lines_seen['test']))
+
+    def _plan_on_valid_line(self, at_line, final_line_count):
+        """Check if a plan is on a valid line."""
+        # Put the common cases first.
+        if at_line == 1 or at_line == final_line_count:
+            return True
+
+        # The plan may only appear on line 2 if the version is at line 1.
+        after_version = (
+            self._lines_seen['version'] and
+            self._lines_seen['version'][0] == 1 and
+            at_line == 2)
+        if after_version:
+            return True
+
+        return False
+
+    def handle_bail(self, reason):
+        """Handle a bail line."""
+        self._add_error('Bailed: {reason}').format(reason=reason)
+
+    def handle_skipping_plan(self):
+        """Handle a plan that contains a SKIP directive."""
+        sys.exit(77)
+
+    def saw_plan(self, expected_tests, at_line):
+        """Record when a plan line was seen."""
+        self._lines_seen['plan'].append((expected_tests, at_line))
+
+    def saw_test(self, ok):
+        """Record when a test line was seen."""
+        self._lines_seen['test'] += 1
+        if not ok:
+            self._lines_seen['failed'] += 1
+
+    def saw_version_at(self, line_counter):
+        """Record when a version line was seen."""
+        self._lines_seen['version'].append(line_counter)
+
+    def _add_error(self, message):
+        self._errors += [message]
+
+
+if __name__ == '__main__':
+    parser = Parser()
+    rules = Rules()
+
+    try:
+        out = subprocess.check_output(sys.argv[1:], universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        sys.stdout.write(e.output)
+        raise e
+
+    line_generator = parser.parse(io.StringIO(out))
+    line_counter = 0
+    for line in line_generator:
+        line_counter += 1
+
+        if line[0] == 'unknown':
+            continue
+
+        if line[0] == 'result':
+            rules.saw_test(line[1])
+            print('{okay} {num} {description} {directive}'.format(
+                okay=('' if line[1] else 'not ') + 'ok', num=line[2],
+                description=line[3], directive=line[4].text))
+        elif line[0] == 'plan':
+            if line[2].skip:
+                rules.handle_skipping_plan()
+            rules.saw_plan(line[1], line_counter)
+        elif line[0] == 'bail':
+            rules.handle_bail(line[1])
+        elif line[0] == 'version':
+            rules.saw_version_at(line_counter)
+        elif line[0] == 'diagnostic':
+            print(line[1])
+
+    rules.check(line_counter)
+    sys.exit(rules.check_errors())


### PR DESCRIPTION
This PR adds an initial implementation of the server side of the AnimationsDbus library as described in the attached ticket.

The server side library is designed to be used like GNOME-Shell
or other compositors which implement surface level animations.

The server uses animations_dbus_server_new_async() to asynchronously
create a new AnimationsDbusServer object and corresponding
AnimationsDbusConnectionManager which will be exported on the bus. One
of the construct properties that the server must provide is an implementation
of a AnimationsDbusServerEffectFactory which is responsible for constructing
the effect "metaclass" (AnimationsDbusServerEffectBridge) on the server side.

On each surface that the server is managing, the server calls
animations_dbus_server_register_surface along with an
implementation of a AnimationsDbusServerSurfaceBridge, which
is an interface providing properties about the surface that
would be interesting to internal clients. Calling register_surface
will export an AnimationsDbusSurface object on the bus for clients
to interact with.

The AnimationsDbusServerSurfaceBridge implementation should have
an attach_effect method which takes an AnimationsDbusServerEffectBridge
and determines if it can be attached to the surface on that event. If
it can be, attach_effect should return an AnimationsDbusServerSurfaceAttachedEffect
implementation, behind which will be private data for that animation
(for instance, progress, spring state) that exists for that animation
on the given surface. It is the server's responsibility to actually
perform the animation using that private data and the settings for that
animation exist on the attached AnimationsDbusServerEffectBridge.

Clients create and attach animations by first registering themselves
using the RegisterClient method on the exported AnimationsDbusConnectionManager
which takes note of their bus name and returns an object path to an
AnimationsDbusAnimationManager (specific to that client), which they can
call CreateAnimation on to create new animation metaclasses. Clients can
then call the AttachEffect method on the exported AnimationsDbusSurface
to attach their effects to the surface. Once the bus name owned by the
client disappears from the bus, all the client specific state will
be automatically cleaned up (eg, animations are detached, private data
for attached animations is destroyed).

Surfaces can have multiple animations attached to a single event. In
case multiple animations are attached, the highest priority attached one
is selected. If the highest priority animation is destroyed, it is removed
from the list and the next highest priority animation will be used. In
general, the latest attached effect by a client has the highest priority.

Both external clients and the server can register animations with
the server (the server would create a new AnimationManager object
using the animation_dbus_server_create_animation_manager method
on the AnimationsDbusServer). When the server attaches an animation
to an AnimationsDbusServerSurface, it uses
the animations_dbus_server_surface_attach_animation_effect_with_server_priority
which gives that attached effect the lowest priority (for instance, if
an external client has already attached a temporary effect to a surface,
that effect has a higher priority than the one attached by the server). This
allows the server to, for instance, globally attach effects to all surfaces
as the "default", but with the ability for external clients on the bus
to override that configuration temporarily.

https://phabricator.endlessm.com/T23314