### PR TITLE
debian: Make sure to include .so.0.0.0 as well

### DIFF
--- a/debian/libanimations-dbus-dev.install
+++ b/debian/libanimations-dbus-dev.install
@@ -1,4 +1,3 @@
 usr/include/animations-dbus-0/*
-usr/lib/*/libanimations-dbus-0.so
 usr/lib/*/pkgconfig/animations-dbus-0.pc
 usr/share/gir-1.0/AnimationsDbus-0.gir

--- a/debian/libanimations-dbus0.install
+++ b/debian/libanimations-dbus0.install
@@ -1,1 +1,1 @@
-usr/lib/*/libanimations-dbus-0.so.0
+usr/lib/*/libanimations-dbus-0.so.*


### PR DESCRIPTION
.so.0 is a symlink to .so.0.0.0 (which is the real library)

https://phabricator.endlessm.com/T23314